### PR TITLE
Random cleanup

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -27,8 +27,8 @@
 		},
 		{
 			"ImportPath": "github.com/rancher/go-rancher/client",
-			"Comment": "v0.1.0-80-gf1d2f8c",
-			"Rev": "f1d2f8c7e015d477204b4201ccccbb67fe13ab84"
+			"Comment": "v0.1.0-98-g595a411",
+			"Rev": "595a41161f4340fab2156d07507458f02b5c9a33"
 		},
 		{
 			"ImportPath": "github.com/rancher/kubernetes-agent/healthcheck",

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/client_test.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/client_test.go
@@ -163,17 +163,9 @@ func TestContainerDelete(t *testing.T) {
 
 func TestContainerNotExists(t *testing.T) {
 	client := newClient(t, PROJECT_URL)
-	_, err := client.Container.ById("badId1")
-	if err == nil {
-		t.Fatal("Should have received an error getting non-existent container.")
-	}
-
-	apiError, ok := err.(*ApiError)
-	if !ok {
-		t.Fatal("Should have received an ApiError.")
-	}
-	if apiError.StatusCode != 404 {
-		t.Fatal("Should have received a 404 and reported it on the ApiError.")
+	ret, err := client.Container.ById("badId1")
+	if ret != nil || err != nil {
+		t.Fatal("Should receive nothing on 404")
 	}
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/common.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/common.go
@@ -339,9 +339,16 @@ func (rancherClient *RancherBaseClient) doModify(method string, url string, crea
 	return nil
 }
 
+func (rancherClient *RancherBaseClient) Create(schemaType string, createObj interface{}, respObject interface{}) error {
+	return rancherClient.doCreate(schemaType, createObj, respObject)
+}
+
 func (rancherClient *RancherBaseClient) doCreate(schemaType string, createObj interface{}, respObject interface{}) error {
 	if createObj == nil {
 		createObj = map[string]string{}
+	}
+	if respObject == nil {
+		respObject = &map[string]interface{}{}
 	}
 	schema, ok := rancherClient.Types[schemaType]
 	if !ok {
@@ -364,6 +371,10 @@ func (rancherClient *RancherBaseClient) doCreate(schemaType string, createObj in
 	return rancherClient.doModify("POST", collectionUrl, createObj, respObject)
 }
 
+func (rancherClient *RancherBaseClient) Update(schemaType string, existing *Resource, updates interface{}, respObject interface{}) error {
+	return rancherClient.doUpdate(schemaType, existing, updates, respObject)
+}
+
 func (rancherClient *RancherBaseClient) doUpdate(schemaType string, existing *Resource, updates interface{}, respObject interface{}) error {
 	if existing == nil {
 		return errors.New("Existing object is nil")
@@ -376,6 +387,10 @@ func (rancherClient *RancherBaseClient) doUpdate(schemaType string, existing *Re
 
 	if updates == nil {
 		updates = map[string]string{}
+	}
+
+	if respObject == nil {
+		respObject = &map[string]interface{}{}
 	}
 
 	schema, ok := rancherClient.Types[schemaType]

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_account.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_account.go
@@ -94,6 +94,11 @@ func (c *AccountClient) List(opts *ListOpts) (*AccountCollection, error) {
 func (c *AccountClient) ById(id string) (*Account, error) {
 	resp := &Account{}
 	err := c.rancherClient.doById(ACCOUNT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_active_setting.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_active_setting.go
@@ -62,6 +62,11 @@ func (c *ActiveSettingClient) List(opts *ListOpts) (*ActiveSettingCollection, er
 func (c *ActiveSettingClient) ById(id string) (*ActiveSetting, error) {
 	resp := &ActiveSetting{}
 	err := c.rancherClient.doById(ACTIVE_SETTING_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_add_load_balancer_input.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_add_load_balancer_input.go
@@ -56,6 +56,11 @@ func (c *AddLoadBalancerInputClient) List(opts *ListOpts) (*AddLoadBalancerInput
 func (c *AddLoadBalancerInputClient) ById(id string) (*AddLoadBalancerInput, error) {
 	resp := &AddLoadBalancerInput{}
 	err := c.rancherClient.doById(ADD_LOAD_BALANCER_INPUT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_add_remove_cluster_host_input.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_add_remove_cluster_host_input.go
@@ -54,6 +54,11 @@ func (c *AddRemoveClusterHostInputClient) List(opts *ListOpts) (*AddRemoveCluste
 func (c *AddRemoveClusterHostInputClient) ById(id string) (*AddRemoveClusterHostInput, error) {
 	resp := &AddRemoveClusterHostInput{}
 	err := c.rancherClient.doById(ADD_REMOVE_CLUSTER_HOST_INPUT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_add_remove_load_balancer_host_input.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_add_remove_load_balancer_host_input.go
@@ -54,6 +54,11 @@ func (c *AddRemoveLoadBalancerHostInputClient) List(opts *ListOpts) (*AddRemoveL
 func (c *AddRemoveLoadBalancerHostInputClient) ById(id string) (*AddRemoveLoadBalancerHostInput, error) {
 	resp := &AddRemoveLoadBalancerHostInput{}
 	err := c.rancherClient.doById(ADD_REMOVE_LOAD_BALANCER_HOST_INPUT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_add_remove_load_balancer_listener_input.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_add_remove_load_balancer_listener_input.go
@@ -54,6 +54,11 @@ func (c *AddRemoveLoadBalancerListenerInputClient) List(opts *ListOpts) (*AddRem
 func (c *AddRemoveLoadBalancerListenerInputClient) ById(id string) (*AddRemoveLoadBalancerListenerInput, error) {
 	resp := &AddRemoveLoadBalancerListenerInput{}
 	err := c.rancherClient.doById(ADD_REMOVE_LOAD_BALANCER_LISTENER_INPUT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_add_remove_load_balancer_service_link_input.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_add_remove_load_balancer_service_link_input.go
@@ -54,6 +54,11 @@ func (c *AddRemoveLoadBalancerServiceLinkInputClient) List(opts *ListOpts) (*Add
 func (c *AddRemoveLoadBalancerServiceLinkInputClient) ById(id string) (*AddRemoveLoadBalancerServiceLinkInput, error) {
 	resp := &AddRemoveLoadBalancerServiceLinkInput{}
 	err := c.rancherClient.doById(ADD_REMOVE_LOAD_BALANCER_SERVICE_LINK_INPUT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_add_remove_load_balancer_target_input.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_add_remove_load_balancer_target_input.go
@@ -54,6 +54,11 @@ func (c *AddRemoveLoadBalancerTargetInputClient) List(opts *ListOpts) (*AddRemov
 func (c *AddRemoveLoadBalancerTargetInputClient) ById(id string) (*AddRemoveLoadBalancerTargetInput, error) {
 	resp := &AddRemoveLoadBalancerTargetInput{}
 	err := c.rancherClient.doById(ADD_REMOVE_LOAD_BALANCER_TARGET_INPUT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_add_remove_service_link_input.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_add_remove_service_link_input.go
@@ -54,6 +54,11 @@ func (c *AddRemoveServiceLinkInputClient) List(opts *ListOpts) (*AddRemoveServic
 func (c *AddRemoveServiceLinkInputClient) ById(id string) (*AddRemoveServiceLinkInput, error) {
 	resp := &AddRemoveServiceLinkInput{}
 	err := c.rancherClient.doById(ADD_REMOVE_SERVICE_LINK_INPUT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_agent.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_agent.go
@@ -98,6 +98,11 @@ func (c *AgentClient) List(opts *ListOpts) (*AgentCollection, error) {
 func (c *AgentClient) ById(id string) (*Agent, error) {
 	resp := &Agent{}
 	err := c.rancherClient.doById(AGENT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_amazonec2config.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_amazonec2config.go
@@ -88,6 +88,11 @@ func (c *Amazonec2ConfigClient) List(opts *ListOpts) (*Amazonec2ConfigCollection
 func (c *Amazonec2ConfigClient) ById(id string) (*Amazonec2Config, error) {
 	resp := &Amazonec2Config{}
 	err := c.rancherClient.doById(AMAZONEC2CONFIG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_api_key.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_api_key.go
@@ -94,6 +94,11 @@ func (c *ApiKeyClient) List(opts *ListOpts) (*ApiKeyCollection, error) {
 func (c *ApiKeyClient) ById(id string) (*ApiKey, error) {
 	resp := &ApiKey{}
 	err := c.rancherClient.doById(API_KEY_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_azure_config.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_azure_config.go
@@ -74,6 +74,11 @@ func (c *AzureConfigClient) List(opts *ListOpts) (*AzureConfigCollection, error)
 func (c *AzureConfigClient) ById(id string) (*AzureConfig, error) {
 	resp := &AzureConfig{}
 	err := c.rancherClient.doById(AZURE_CONFIG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_certificate.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_certificate.go
@@ -108,6 +108,11 @@ func (c *CertificateClient) List(opts *ListOpts) (*CertificateCollection, error)
 func (c *CertificateClient) ById(id string) (*Certificate, error) {
 	resp := &Certificate{}
 	err := c.rancherClient.doById(CERTIFICATE_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_change_secret_input.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_change_secret_input.go
@@ -56,6 +56,11 @@ func (c *ChangeSecretInputClient) List(opts *ListOpts) (*ChangeSecretInputCollec
 func (c *ChangeSecretInputClient) ById(id string) (*ChangeSecretInput, error) {
 	resp := &ChangeSecretInput{}
 	err := c.rancherClient.doById(CHANGE_SECRET_INPUT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_client.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_client.go
@@ -17,6 +17,9 @@ type RancherClient struct {
 	InstanceHealthCheck                      InstanceHealthCheckOperations
 	ServiceLink                              ServiceLinkOperations
 	ServiceUpgrade                           ServiceUpgradeOperations
+	ServiceUpgradeStrategy                   ServiceUpgradeStrategyOperations
+	InServiceUpgradeStrategy                 InServiceUpgradeStrategyOperations
+	ToServiceUpgradeStrategy                 ToServiceUpgradeStrategyOperations
 	AddLoadBalancerInput                     AddLoadBalancerInputOperations
 	AddRemoveClusterHostInput                AddRemoveClusterHostInputOperations
 	AddRemoveLoadBalancerHostInput           AddRemoveLoadBalancerHostInputOperations
@@ -54,6 +57,10 @@ type RancherClient struct {
 	PullTask                                 PullTaskOperations
 	ExternalVolumeEvent                      ExternalVolumeEventOperations
 	ExternalStoragePoolEvent                 ExternalStoragePoolEventOperations
+	ExternalServiceEvent                     ExternalServiceEventOperations
+	EnvironmentUpgrade                       EnvironmentUpgradeOperations
+	ExternalDnsEvent                         ExternalDnsEventOperations
+	ExternalHostEvent                        ExternalHostEventOperations
 	Account                                  AccountOperations
 	Agent                                    AgentOperations
 	Certificate                              CertificateOperations
@@ -123,6 +130,7 @@ type RancherClient struct {
 	PacketConfig                             PacketConfigOperations
 	RackspaceConfig                          RackspaceConfigOperations
 	SoftlayerConfig                          SoftlayerConfigOperations
+	UbiquityConfig                           UbiquityConfigOperations
 	VirtualboxConfig                         VirtualboxConfigOperations
 	VmwarevcloudairConfig                    VmwarevcloudairConfigOperations
 	VmwarevsphereConfig                      VmwarevsphereConfigOperations
@@ -153,6 +161,9 @@ func constructClient() *RancherClient {
 	client.InstanceHealthCheck = newInstanceHealthCheckClient(client)
 	client.ServiceLink = newServiceLinkClient(client)
 	client.ServiceUpgrade = newServiceUpgradeClient(client)
+	client.ServiceUpgradeStrategy = newServiceUpgradeStrategyClient(client)
+	client.InServiceUpgradeStrategy = newInServiceUpgradeStrategyClient(client)
+	client.ToServiceUpgradeStrategy = newToServiceUpgradeStrategyClient(client)
 	client.AddLoadBalancerInput = newAddLoadBalancerInputClient(client)
 	client.AddRemoveClusterHostInput = newAddRemoveClusterHostInputClient(client)
 	client.AddRemoveLoadBalancerHostInput = newAddRemoveLoadBalancerHostInputClient(client)
@@ -190,6 +201,10 @@ func constructClient() *RancherClient {
 	client.PullTask = newPullTaskClient(client)
 	client.ExternalVolumeEvent = newExternalVolumeEventClient(client)
 	client.ExternalStoragePoolEvent = newExternalStoragePoolEventClient(client)
+	client.ExternalServiceEvent = newExternalServiceEventClient(client)
+	client.EnvironmentUpgrade = newEnvironmentUpgradeClient(client)
+	client.ExternalDnsEvent = newExternalDnsEventClient(client)
+	client.ExternalHostEvent = newExternalHostEventClient(client)
 	client.Account = newAccountClient(client)
 	client.Agent = newAgentClient(client)
 	client.Certificate = newCertificateClient(client)
@@ -259,6 +274,7 @@ func constructClient() *RancherClient {
 	client.PacketConfig = newPacketConfigClient(client)
 	client.RackspaceConfig = newRackspaceConfigClient(client)
 	client.SoftlayerConfig = newSoftlayerConfigClient(client)
+	client.UbiquityConfig = newUbiquityConfigClient(client)
 	client.VirtualboxConfig = newVirtualboxConfigClient(client)
 	client.VmwarevcloudairConfig = newVmwarevcloudairConfigClient(client)
 	client.VmwarevsphereConfig = newVmwarevsphereConfigClient(client)

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_cluster.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_cluster.go
@@ -76,6 +76,8 @@ type ClusterOperations interface {
 
 	ActionDeactivate(*Cluster) (*Host, error)
 
+	ActionDockersocket(*Cluster) (*HostAccess, error)
+
 	ActionPurge(*Cluster) (*Host, error)
 
 	ActionRemove(*Cluster) (*Host, error)
@@ -114,6 +116,11 @@ func (c *ClusterClient) List(opts *ListOpts) (*ClusterCollection, error) {
 func (c *ClusterClient) ById(id string) (*Cluster, error) {
 	resp := &Cluster{}
 	err := c.rancherClient.doById(CLUSTER_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 
@@ -153,6 +160,15 @@ func (c *ClusterClient) ActionDeactivate(resource *Cluster) (*Host, error) {
 	resp := &Host{}
 
 	err := c.rancherClient.doAction(CLUSTER_TYPE, "deactivate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ClusterClient) ActionDockersocket(resource *Cluster) (*HostAccess, error) {
+
+	resp := &HostAccess{}
+
+	err := c.rancherClient.doAction(CLUSTER_TYPE, "dockersocket", &resource.Resource, nil, resp)
 
 	return resp, err
 }

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_compose_config.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_compose_config.go
@@ -56,6 +56,11 @@ func (c *ComposeConfigClient) List(opts *ListOpts) (*ComposeConfigCollection, er
 func (c *ComposeConfigClient) ById(id string) (*ComposeConfig, error) {
 	resp := &ComposeConfig{}
 	err := c.rancherClient.doById(COMPOSE_CONFIG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_compose_config_input.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_compose_config_input.go
@@ -54,6 +54,11 @@ func (c *ComposeConfigInputClient) List(opts *ListOpts) (*ComposeConfigInputColl
 func (c *ComposeConfigInputClient) ById(id string) (*ComposeConfigInput, error) {
 	resp := &ComposeConfigInput{}
 	err := c.rancherClient.doById(COMPOSE_CONFIG_INPUT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_config_item.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_config_item.go
@@ -56,6 +56,11 @@ func (c *ConfigItemClient) List(opts *ListOpts) (*ConfigItemCollection, error) {
 func (c *ConfigItemClient) ById(id string) (*ConfigItem, error) {
 	resp := &ConfigItem{}
 	err := c.rancherClient.doById(CONFIG_ITEM_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_config_item_status.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_config_item_status.go
@@ -68,6 +68,11 @@ func (c *ConfigItemStatusClient) List(opts *ListOpts) (*ConfigItemStatusCollecti
 func (c *ConfigItemStatusClient) ById(id string) (*ConfigItemStatus, error) {
 	resp := &ConfigItemStatus{}
 	err := c.rancherClient.doById(CONFIG_ITEM_STATUS_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_container.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_container.go
@@ -119,6 +119,8 @@ type Container struct {
 
 	SecurityOpt []string `json:"securityOpt,omitempty" yaml:"security_opt,omitempty"`
 
+	StartCount int64 `json:"startCount,omitempty" yaml:"start_count,omitempty"`
+
 	StartOnCreate bool `json:"startOnCreate,omitempty" yaml:"start_on_create,omitempty"`
 
 	State string `json:"state,omitempty" yaml:"state,omitempty"`
@@ -226,6 +228,11 @@ func (c *ContainerClient) List(opts *ListOpts) (*ContainerCollection, error) {
 func (c *ContainerClient) ById(id string) (*Container, error) {
 	resp := &Container{}
 	err := c.rancherClient.doById(CONTAINER_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_container_event.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_container_event.go
@@ -86,6 +86,11 @@ func (c *ContainerEventClient) List(opts *ListOpts) (*ContainerEventCollection, 
 func (c *ContainerEventClient) ById(id string) (*ContainerEvent, error) {
 	resp := &ContainerEvent{}
 	err := c.rancherClient.doById(CONTAINER_EVENT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_container_exec.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_container_exec.go
@@ -60,6 +60,11 @@ func (c *ContainerExecClient) List(opts *ListOpts) (*ContainerExecCollection, er
 func (c *ContainerExecClient) ById(id string) (*ContainerExec, error) {
 	resp := &ContainerExec{}
 	err := c.rancherClient.doById(CONTAINER_EXEC_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_container_logs.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_container_logs.go
@@ -56,6 +56,11 @@ func (c *ContainerLogsClient) List(opts *ListOpts) (*ContainerLogsCollection, er
 func (c *ContainerLogsClient) ById(id string) (*ContainerLogs, error) {
 	resp := &ContainerLogs{}
 	err := c.rancherClient.doById(CONTAINER_LOGS_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_credential.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_credential.go
@@ -94,6 +94,11 @@ func (c *CredentialClient) List(opts *ListOpts) (*CredentialCollection, error) {
 func (c *CredentialClient) ById(id string) (*Credential, error) {
 	resp := &Credential{}
 	err := c.rancherClient.doById(CREDENTIAL_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_databasechangelog.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_databasechangelog.go
@@ -72,6 +72,11 @@ func (c *DatabasechangelogClient) List(opts *ListOpts) (*DatabasechangelogCollec
 func (c *DatabasechangelogClient) ById(id string) (*Databasechangelog, error) {
 	resp := &Databasechangelog{}
 	err := c.rancherClient.doById(DATABASECHANGELOG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_databasechangeloglock.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_databasechangeloglock.go
@@ -58,6 +58,11 @@ func (c *DatabasechangeloglockClient) List(opts *ListOpts) (*Databasechangeloglo
 func (c *DatabasechangeloglockClient) ById(id string) (*Databasechangeloglock, error) {
 	resp := &Databasechangeloglock{}
 	err := c.rancherClient.doById(DATABASECHANGELOGLOCK_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_digitalocean_config.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_digitalocean_config.go
@@ -68,6 +68,11 @@ func (c *DigitaloceanConfigClient) List(opts *ListOpts) (*DigitaloceanConfigColl
 func (c *DigitaloceanConfigClient) ById(id string) (*DigitaloceanConfig, error) {
 	resp := &DigitaloceanConfig{}
 	err := c.rancherClient.doById(DIGITALOCEAN_CONFIG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_dns_service.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_dns_service.go
@@ -17,9 +17,13 @@ type DnsService struct {
 
 	EnvironmentId string `json:"environmentId,omitempty" yaml:"environment_id,omitempty"`
 
+	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
+
+	Fqdn string `json:"fqdn,omitempty" yaml:"fqdn,omitempty"`
+
 	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
 
-	LaunchConfig LaunchConfig `json:"launchConfig,omitempty" yaml:"launch_config,omitempty"`
+	LaunchConfig *LaunchConfig `json:"launchConfig,omitempty" yaml:"launch_config,omitempty"`
 
 	Metadata map[string]interface{} `json:"metadata,omitempty" yaml:"metadata,omitempty"`
 
@@ -64,15 +68,21 @@ type DnsServiceOperations interface {
 
 	ActionAddservicelink(*DnsService, *AddRemoveServiceLinkInput) (*Service, error)
 
+	ActionCancelrollback(*DnsService) (*Service, error)
+
 	ActionCancelupgrade(*DnsService) (*Service, error)
 
 	ActionCreate(*DnsService) (*Service, error)
 
 	ActionDeactivate(*DnsService) (*Service, error)
 
+	ActionFinishupgrade(*DnsService) (*Service, error)
+
 	ActionRemove(*DnsService) (*Service, error)
 
 	ActionRemoveservicelink(*DnsService, *AddRemoveServiceLinkInput) (*Service, error)
+
+	ActionRollback(*DnsService) (*Service, error)
 
 	ActionSetservicelinks(*DnsService, *SetServiceLinksInput) (*Service, error)
 
@@ -108,6 +118,11 @@ func (c *DnsServiceClient) List(opts *ListOpts) (*DnsServiceCollection, error) {
 func (c *DnsServiceClient) ById(id string) (*DnsService, error) {
 	resp := &DnsService{}
 	err := c.rancherClient.doById(DNS_SERVICE_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 
@@ -129,6 +144,15 @@ func (c *DnsServiceClient) ActionAddservicelink(resource *DnsService, input *Add
 	resp := &Service{}
 
 	err := c.rancherClient.doAction(DNS_SERVICE_TYPE, "addservicelink", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *DnsServiceClient) ActionCancelrollback(resource *DnsService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(DNS_SERVICE_TYPE, "cancelrollback", &resource.Resource, nil, resp)
 
 	return resp, err
 }
@@ -160,6 +184,15 @@ func (c *DnsServiceClient) ActionDeactivate(resource *DnsService) (*Service, err
 	return resp, err
 }
 
+func (c *DnsServiceClient) ActionFinishupgrade(resource *DnsService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(DNS_SERVICE_TYPE, "finishupgrade", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
 func (c *DnsServiceClient) ActionRemove(resource *DnsService) (*Service, error) {
 
 	resp := &Service{}
@@ -174,6 +207,15 @@ func (c *DnsServiceClient) ActionRemoveservicelink(resource *DnsService, input *
 	resp := &Service{}
 
 	err := c.rancherClient.doAction(DNS_SERVICE_TYPE, "removeservicelink", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *DnsServiceClient) ActionRollback(resource *DnsService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(DNS_SERVICE_TYPE, "rollback", &resource.Resource, nil, resp)
 
 	return resp, err
 }

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_docker_build.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_docker_build.go
@@ -64,6 +64,11 @@ func (c *DockerBuildClient) List(opts *ListOpts) (*DockerBuildCollection, error)
 func (c *DockerBuildClient) ById(id string) (*DockerBuild, error) {
 	resp := &DockerBuild{}
 	err := c.rancherClient.doById(DOCKER_BUILD_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_environment.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_environment.go
@@ -19,9 +19,13 @@ type Environment struct {
 
 	Environment map[string]interface{} `json:"environment,omitempty" yaml:"environment,omitempty"`
 
+	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
+
 	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
 
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	PreviousExternalId string `json:"previousExternalId,omitempty" yaml:"previous_external_id,omitempty"`
 
 	RancherCompose string `json:"rancherCompose,omitempty" yaml:"rancher_compose,omitempty"`
 
@@ -56,15 +60,29 @@ type EnvironmentOperations interface {
 	ById(id string) (*Environment, error)
 	Delete(container *Environment) error
 
+	ActionActivateservices(*Environment) (*Environment, error)
+
+	ActionCancelrollback(*Environment) (*Environment, error)
+
+	ActionCancelupgrade(*Environment) (*Environment, error)
+
 	ActionCreate(*Environment) (*Environment, error)
+
+	ActionDeactivateservices(*Environment) (*Environment, error)
 
 	ActionError(*Environment) (*Environment, error)
 
 	ActionExportconfig(*Environment, *ComposeConfigInput) (*ComposeConfig, error)
 
+	ActionFinishupgrade(*Environment) (*Environment, error)
+
 	ActionRemove(*Environment) (*Environment, error)
 
+	ActionRollback(*Environment) (*Environment, error)
+
 	ActionUpdate(*Environment) (*Environment, error)
+
+	ActionUpgrade(*Environment, *EnvironmentUpgrade) (*Environment, error)
 }
 
 func newEnvironmentClient(rancherClient *RancherClient) *EnvironmentClient {
@@ -94,6 +112,11 @@ func (c *EnvironmentClient) List(opts *ListOpts) (*EnvironmentCollection, error)
 func (c *EnvironmentClient) ById(id string) (*Environment, error) {
 	resp := &Environment{}
 	err := c.rancherClient.doById(ENVIRONMENT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 
@@ -101,11 +124,47 @@ func (c *EnvironmentClient) Delete(container *Environment) error {
 	return c.rancherClient.doResourceDelete(ENVIRONMENT_TYPE, &container.Resource)
 }
 
+func (c *EnvironmentClient) ActionActivateservices(resource *Environment) (*Environment, error) {
+
+	resp := &Environment{}
+
+	err := c.rancherClient.doAction(ENVIRONMENT_TYPE, "activateservices", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *EnvironmentClient) ActionCancelrollback(resource *Environment) (*Environment, error) {
+
+	resp := &Environment{}
+
+	err := c.rancherClient.doAction(ENVIRONMENT_TYPE, "cancelrollback", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *EnvironmentClient) ActionCancelupgrade(resource *Environment) (*Environment, error) {
+
+	resp := &Environment{}
+
+	err := c.rancherClient.doAction(ENVIRONMENT_TYPE, "cancelupgrade", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
 func (c *EnvironmentClient) ActionCreate(resource *Environment) (*Environment, error) {
 
 	resp := &Environment{}
 
 	err := c.rancherClient.doAction(ENVIRONMENT_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *EnvironmentClient) ActionDeactivateservices(resource *Environment) (*Environment, error) {
+
+	resp := &Environment{}
+
+	err := c.rancherClient.doAction(ENVIRONMENT_TYPE, "deactivateservices", &resource.Resource, nil, resp)
 
 	return resp, err
 }
@@ -128,6 +187,15 @@ func (c *EnvironmentClient) ActionExportconfig(resource *Environment, input *Com
 	return resp, err
 }
 
+func (c *EnvironmentClient) ActionFinishupgrade(resource *Environment) (*Environment, error) {
+
+	resp := &Environment{}
+
+	err := c.rancherClient.doAction(ENVIRONMENT_TYPE, "finishupgrade", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
 func (c *EnvironmentClient) ActionRemove(resource *Environment) (*Environment, error) {
 
 	resp := &Environment{}
@@ -137,11 +205,29 @@ func (c *EnvironmentClient) ActionRemove(resource *Environment) (*Environment, e
 	return resp, err
 }
 
+func (c *EnvironmentClient) ActionRollback(resource *Environment) (*Environment, error) {
+
+	resp := &Environment{}
+
+	err := c.rancherClient.doAction(ENVIRONMENT_TYPE, "rollback", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
 func (c *EnvironmentClient) ActionUpdate(resource *Environment) (*Environment, error) {
 
 	resp := &Environment{}
 
 	err := c.rancherClient.doAction(ENVIRONMENT_TYPE, "update", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *EnvironmentClient) ActionUpgrade(resource *Environment, input *EnvironmentUpgrade) (*Environment, error) {
+
+	resp := &Environment{}
+
+	err := c.rancherClient.doAction(ENVIRONMENT_TYPE, "upgrade", &resource.Resource, input, resp)
 
 	return resp, err
 }

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_environment_upgrade.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_environment_upgrade.go
@@ -1,0 +1,73 @@
+package client
+
+const (
+	ENVIRONMENT_UPGRADE_TYPE = "environmentUpgrade"
+)
+
+type EnvironmentUpgrade struct {
+	Resource
+
+	DockerCompose string `json:"dockerCompose,omitempty" yaml:"docker_compose,omitempty"`
+
+	Environment map[string]interface{} `json:"environment,omitempty" yaml:"environment,omitempty"`
+
+	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
+
+	RancherCompose string `json:"rancherCompose,omitempty" yaml:"rancher_compose,omitempty"`
+}
+
+type EnvironmentUpgradeCollection struct {
+	Collection
+	Data []EnvironmentUpgrade `json:"data,omitempty"`
+}
+
+type EnvironmentUpgradeClient struct {
+	rancherClient *RancherClient
+}
+
+type EnvironmentUpgradeOperations interface {
+	List(opts *ListOpts) (*EnvironmentUpgradeCollection, error)
+	Create(opts *EnvironmentUpgrade) (*EnvironmentUpgrade, error)
+	Update(existing *EnvironmentUpgrade, updates interface{}) (*EnvironmentUpgrade, error)
+	ById(id string) (*EnvironmentUpgrade, error)
+	Delete(container *EnvironmentUpgrade) error
+}
+
+func newEnvironmentUpgradeClient(rancherClient *RancherClient) *EnvironmentUpgradeClient {
+	return &EnvironmentUpgradeClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *EnvironmentUpgradeClient) Create(container *EnvironmentUpgrade) (*EnvironmentUpgrade, error) {
+	resp := &EnvironmentUpgrade{}
+	err := c.rancherClient.doCreate(ENVIRONMENT_UPGRADE_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *EnvironmentUpgradeClient) Update(existing *EnvironmentUpgrade, updates interface{}) (*EnvironmentUpgrade, error) {
+	resp := &EnvironmentUpgrade{}
+	err := c.rancherClient.doUpdate(ENVIRONMENT_UPGRADE_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *EnvironmentUpgradeClient) List(opts *ListOpts) (*EnvironmentUpgradeCollection, error) {
+	resp := &EnvironmentUpgradeCollection{}
+	err := c.rancherClient.doList(ENVIRONMENT_UPGRADE_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *EnvironmentUpgradeClient) ById(id string) (*EnvironmentUpgrade, error) {
+	resp := &EnvironmentUpgrade{}
+	err := c.rancherClient.doById(ENVIRONMENT_UPGRADE_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *EnvironmentUpgradeClient) Delete(container *EnvironmentUpgrade) error {
+	return c.rancherClient.doResourceDelete(ENVIRONMENT_UPGRADE_TYPE, &container.Resource)
+}

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_exoscale_config.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_exoscale_config.go
@@ -68,6 +68,11 @@ func (c *ExoscaleConfigClient) List(opts *ListOpts) (*ExoscaleConfigCollection, 
 func (c *ExoscaleConfigClient) ById(id string) (*ExoscaleConfig, error) {
 	resp := &ExoscaleConfig{}
 	err := c.rancherClient.doById(EXOSCALE_CONFIG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_extension_implementation.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_extension_implementation.go
@@ -58,6 +58,11 @@ func (c *ExtensionImplementationClient) List(opts *ListOpts) (*ExtensionImplemen
 func (c *ExtensionImplementationClient) ById(id string) (*ExtensionImplementation, error) {
 	resp := &ExtensionImplementation{}
 	err := c.rancherClient.doById(EXTENSION_IMPLEMENTATION_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_extension_point.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_extension_point.go
@@ -62,6 +62,11 @@ func (c *ExtensionPointClient) List(opts *ListOpts) (*ExtensionPointCollection, 
 func (c *ExtensionPointClient) ById(id string) (*ExtensionPoint, error) {
 	resp := &ExtensionPoint{}
 	err := c.rancherClient.doById(EXTENSION_POINT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_external_dns_event.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_external_dns_event.go
@@ -1,0 +1,117 @@
+package client
+
+const (
+	EXTERNAL_DNS_EVENT_TYPE = "externalDnsEvent"
+)
+
+type ExternalDnsEvent struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	EventType string `json:"eventType,omitempty" yaml:"event_type,omitempty"`
+
+	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
+
+	Fqdn string `json:"fqdn,omitempty" yaml:"fqdn,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	ReportedAccountId string `json:"reportedAccountId,omitempty" yaml:"reported_account_id,omitempty"`
+
+	ServiceName string `json:"serviceName,omitempty" yaml:"service_name,omitempty"`
+
+	StackName string `json:"stackName,omitempty" yaml:"stack_name,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type ExternalDnsEventCollection struct {
+	Collection
+	Data []ExternalDnsEvent `json:"data,omitempty"`
+}
+
+type ExternalDnsEventClient struct {
+	rancherClient *RancherClient
+}
+
+type ExternalDnsEventOperations interface {
+	List(opts *ListOpts) (*ExternalDnsEventCollection, error)
+	Create(opts *ExternalDnsEvent) (*ExternalDnsEvent, error)
+	Update(existing *ExternalDnsEvent, updates interface{}) (*ExternalDnsEvent, error)
+	ById(id string) (*ExternalDnsEvent, error)
+	Delete(container *ExternalDnsEvent) error
+
+	ActionCreate(*ExternalDnsEvent) (*ExternalEvent, error)
+
+	ActionRemove(*ExternalDnsEvent) (*ExternalEvent, error)
+}
+
+func newExternalDnsEventClient(rancherClient *RancherClient) *ExternalDnsEventClient {
+	return &ExternalDnsEventClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ExternalDnsEventClient) Create(container *ExternalDnsEvent) (*ExternalDnsEvent, error) {
+	resp := &ExternalDnsEvent{}
+	err := c.rancherClient.doCreate(EXTERNAL_DNS_EVENT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ExternalDnsEventClient) Update(existing *ExternalDnsEvent, updates interface{}) (*ExternalDnsEvent, error) {
+	resp := &ExternalDnsEvent{}
+	err := c.rancherClient.doUpdate(EXTERNAL_DNS_EVENT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ExternalDnsEventClient) List(opts *ListOpts) (*ExternalDnsEventCollection, error) {
+	resp := &ExternalDnsEventCollection{}
+	err := c.rancherClient.doList(EXTERNAL_DNS_EVENT_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ExternalDnsEventClient) ById(id string) (*ExternalDnsEvent, error) {
+	resp := &ExternalDnsEvent{}
+	err := c.rancherClient.doById(EXTERNAL_DNS_EVENT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ExternalDnsEventClient) Delete(container *ExternalDnsEvent) error {
+	return c.rancherClient.doResourceDelete(EXTERNAL_DNS_EVENT_TYPE, &container.Resource)
+}
+
+func (c *ExternalDnsEventClient) ActionCreate(resource *ExternalDnsEvent) (*ExternalEvent, error) {
+
+	resp := &ExternalEvent{}
+
+	err := c.rancherClient.doAction(EXTERNAL_DNS_EVENT_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ExternalDnsEventClient) ActionRemove(resource *ExternalDnsEvent) (*ExternalEvent, error) {
+
+	resp := &ExternalEvent{}
+
+	err := c.rancherClient.doAction(EXTERNAL_DNS_EVENT_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_external_event.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_external_event.go
@@ -80,6 +80,11 @@ func (c *ExternalEventClient) List(opts *ListOpts) (*ExternalEventCollection, er
 func (c *ExternalEventClient) ById(id string) (*ExternalEvent, error) {
 	resp := &ExternalEvent{}
 	err := c.rancherClient.doById(EXTERNAL_EVENT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_external_handler.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_external_handler.go
@@ -98,6 +98,11 @@ func (c *ExternalHandlerClient) List(opts *ListOpts) (*ExternalHandlerCollection
 func (c *ExternalHandlerClient) ById(id string) (*ExternalHandler, error) {
 	resp := &ExternalHandler{}
 	err := c.rancherClient.doById(EXTERNAL_HANDLER_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_external_handler_external_handler_process_map.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_external_handler_external_handler_process_map.go
@@ -96,6 +96,11 @@ func (c *ExternalHandlerExternalHandlerProcessMapClient) List(opts *ListOpts) (*
 func (c *ExternalHandlerExternalHandlerProcessMapClient) ById(id string) (*ExternalHandlerExternalHandlerProcessMap, error) {
 	resp := &ExternalHandlerExternalHandlerProcessMap{}
 	err := c.rancherClient.doById(EXTERNAL_HANDLER_EXTERNAL_HANDLER_PROCESS_MAP_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_external_handler_process.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_external_handler_process.go
@@ -90,6 +90,11 @@ func (c *ExternalHandlerProcessClient) List(opts *ListOpts) (*ExternalHandlerPro
 func (c *ExternalHandlerProcessClient) ById(id string) (*ExternalHandlerProcess, error) {
 	resp := &ExternalHandlerProcess{}
 	err := c.rancherClient.doById(EXTERNAL_HANDLER_PROCESS_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_external_handler_process_config.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_external_handler_process_config.go
@@ -56,6 +56,11 @@ func (c *ExternalHandlerProcessConfigClient) List(opts *ListOpts) (*ExternalHand
 func (c *ExternalHandlerProcessConfigClient) ById(id string) (*ExternalHandlerProcessConfig, error) {
 	resp := &ExternalHandlerProcessConfig{}
 	err := c.rancherClient.doById(EXTERNAL_HANDLER_PROCESS_CONFIG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_external_host_event.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_external_host_event.go
@@ -1,0 +1,117 @@
+package client
+
+const (
+	EXTERNAL_HOST_EVENT_TYPE = "externalHostEvent"
+)
+
+type ExternalHostEvent struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	DeleteHost bool `json:"deleteHost,omitempty" yaml:"delete_host,omitempty"`
+
+	EventType string `json:"eventType,omitempty" yaml:"event_type,omitempty"`
+
+	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
+
+	HostId string `json:"hostId,omitempty" yaml:"host_id,omitempty"`
+
+	HostLabel string `json:"hostLabel,omitempty" yaml:"host_label,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	ReportedAccountId string `json:"reportedAccountId,omitempty" yaml:"reported_account_id,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type ExternalHostEventCollection struct {
+	Collection
+	Data []ExternalHostEvent `json:"data,omitempty"`
+}
+
+type ExternalHostEventClient struct {
+	rancherClient *RancherClient
+}
+
+type ExternalHostEventOperations interface {
+	List(opts *ListOpts) (*ExternalHostEventCollection, error)
+	Create(opts *ExternalHostEvent) (*ExternalHostEvent, error)
+	Update(existing *ExternalHostEvent, updates interface{}) (*ExternalHostEvent, error)
+	ById(id string) (*ExternalHostEvent, error)
+	Delete(container *ExternalHostEvent) error
+
+	ActionCreate(*ExternalHostEvent) (*ExternalEvent, error)
+
+	ActionRemove(*ExternalHostEvent) (*ExternalEvent, error)
+}
+
+func newExternalHostEventClient(rancherClient *RancherClient) *ExternalHostEventClient {
+	return &ExternalHostEventClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ExternalHostEventClient) Create(container *ExternalHostEvent) (*ExternalHostEvent, error) {
+	resp := &ExternalHostEvent{}
+	err := c.rancherClient.doCreate(EXTERNAL_HOST_EVENT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ExternalHostEventClient) Update(existing *ExternalHostEvent, updates interface{}) (*ExternalHostEvent, error) {
+	resp := &ExternalHostEvent{}
+	err := c.rancherClient.doUpdate(EXTERNAL_HOST_EVENT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ExternalHostEventClient) List(opts *ListOpts) (*ExternalHostEventCollection, error) {
+	resp := &ExternalHostEventCollection{}
+	err := c.rancherClient.doList(EXTERNAL_HOST_EVENT_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ExternalHostEventClient) ById(id string) (*ExternalHostEvent, error) {
+	resp := &ExternalHostEvent{}
+	err := c.rancherClient.doById(EXTERNAL_HOST_EVENT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ExternalHostEventClient) Delete(container *ExternalHostEvent) error {
+	return c.rancherClient.doResourceDelete(EXTERNAL_HOST_EVENT_TYPE, &container.Resource)
+}
+
+func (c *ExternalHostEventClient) ActionCreate(resource *ExternalHostEvent) (*ExternalEvent, error) {
+
+	resp := &ExternalEvent{}
+
+	err := c.rancherClient.doAction(EXTERNAL_HOST_EVENT_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ExternalHostEventClient) ActionRemove(resource *ExternalHostEvent) (*ExternalEvent, error) {
+
+	resp := &ExternalEvent{}
+
+	err := c.rancherClient.doAction(EXTERNAL_HOST_EVENT_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_external_service.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_external_service.go
@@ -17,7 +17,11 @@ type ExternalService struct {
 
 	EnvironmentId string `json:"environmentId,omitempty" yaml:"environment_id,omitempty"`
 
+	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
+
 	ExternalIpAddresses []string `json:"externalIpAddresses,omitempty" yaml:"external_ip_addresses,omitempty"`
+
+	Fqdn string `json:"fqdn,omitempty" yaml:"fqdn,omitempty"`
 
 	HealthCheck *InstanceHealthCheck `json:"healthCheck,omitempty" yaml:"health_check,omitempty"`
 
@@ -25,7 +29,7 @@ type ExternalService struct {
 
 	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
 
-	LaunchConfig LaunchConfig `json:"launchConfig,omitempty" yaml:"launch_config,omitempty"`
+	LaunchConfig *LaunchConfig `json:"launchConfig,omitempty" yaml:"launch_config,omitempty"`
 
 	Metadata map[string]interface{} `json:"metadata,omitempty" yaml:"metadata,omitempty"`
 
@@ -70,15 +74,21 @@ type ExternalServiceOperations interface {
 
 	ActionAddservicelink(*ExternalService, *AddRemoveServiceLinkInput) (*Service, error)
 
+	ActionCancelrollback(*ExternalService) (*Service, error)
+
 	ActionCancelupgrade(*ExternalService) (*Service, error)
 
 	ActionCreate(*ExternalService) (*Service, error)
 
 	ActionDeactivate(*ExternalService) (*Service, error)
 
+	ActionFinishupgrade(*ExternalService) (*Service, error)
+
 	ActionRemove(*ExternalService) (*Service, error)
 
 	ActionRemoveservicelink(*ExternalService, *AddRemoveServiceLinkInput) (*Service, error)
+
+	ActionRollback(*ExternalService) (*Service, error)
 
 	ActionSetservicelinks(*ExternalService, *SetServiceLinksInput) (*Service, error)
 
@@ -114,6 +124,11 @@ func (c *ExternalServiceClient) List(opts *ListOpts) (*ExternalServiceCollection
 func (c *ExternalServiceClient) ById(id string) (*ExternalService, error) {
 	resp := &ExternalService{}
 	err := c.rancherClient.doById(EXTERNAL_SERVICE_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 
@@ -135,6 +150,15 @@ func (c *ExternalServiceClient) ActionAddservicelink(resource *ExternalService, 
 	resp := &Service{}
 
 	err := c.rancherClient.doAction(EXTERNAL_SERVICE_TYPE, "addservicelink", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *ExternalServiceClient) ActionCancelrollback(resource *ExternalService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(EXTERNAL_SERVICE_TYPE, "cancelrollback", &resource.Resource, nil, resp)
 
 	return resp, err
 }
@@ -166,6 +190,15 @@ func (c *ExternalServiceClient) ActionDeactivate(resource *ExternalService) (*Se
 	return resp, err
 }
 
+func (c *ExternalServiceClient) ActionFinishupgrade(resource *ExternalService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(EXTERNAL_SERVICE_TYPE, "finishupgrade", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
 func (c *ExternalServiceClient) ActionRemove(resource *ExternalService) (*Service, error) {
 
 	resp := &Service{}
@@ -180,6 +213,15 @@ func (c *ExternalServiceClient) ActionRemoveservicelink(resource *ExternalServic
 	resp := &Service{}
 
 	err := c.rancherClient.doAction(EXTERNAL_SERVICE_TYPE, "removeservicelink", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *ExternalServiceClient) ActionRollback(resource *ExternalService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(EXTERNAL_SERVICE_TYPE, "rollback", &resource.Resource, nil, resp)
 
 	return resp, err
 }

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_external_service_event.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_external_service_event.go
@@ -1,0 +1,115 @@
+package client
+
+const (
+	EXTERNAL_SERVICE_EVENT_TYPE = "externalServiceEvent"
+)
+
+type ExternalServiceEvent struct {
+	Resource
+
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
+
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
+
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
+
+	Environment interface{} `json:"environment,omitempty" yaml:"environment,omitempty"`
+
+	EventType string `json:"eventType,omitempty" yaml:"event_type,omitempty"`
+
+	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
+
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
+
+	ReportedAccountId string `json:"reportedAccountId,omitempty" yaml:"reported_account_id,omitempty"`
+
+	Service interface{} `json:"service,omitempty" yaml:"service,omitempty"`
+
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
+
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
+
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
+
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
+
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
+}
+
+type ExternalServiceEventCollection struct {
+	Collection
+	Data []ExternalServiceEvent `json:"data,omitempty"`
+}
+
+type ExternalServiceEventClient struct {
+	rancherClient *RancherClient
+}
+
+type ExternalServiceEventOperations interface {
+	List(opts *ListOpts) (*ExternalServiceEventCollection, error)
+	Create(opts *ExternalServiceEvent) (*ExternalServiceEvent, error)
+	Update(existing *ExternalServiceEvent, updates interface{}) (*ExternalServiceEvent, error)
+	ById(id string) (*ExternalServiceEvent, error)
+	Delete(container *ExternalServiceEvent) error
+
+	ActionCreate(*ExternalServiceEvent) (*ExternalEvent, error)
+
+	ActionRemove(*ExternalServiceEvent) (*ExternalEvent, error)
+}
+
+func newExternalServiceEventClient(rancherClient *RancherClient) *ExternalServiceEventClient {
+	return &ExternalServiceEventClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ExternalServiceEventClient) Create(container *ExternalServiceEvent) (*ExternalServiceEvent, error) {
+	resp := &ExternalServiceEvent{}
+	err := c.rancherClient.doCreate(EXTERNAL_SERVICE_EVENT_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ExternalServiceEventClient) Update(existing *ExternalServiceEvent, updates interface{}) (*ExternalServiceEvent, error) {
+	resp := &ExternalServiceEvent{}
+	err := c.rancherClient.doUpdate(EXTERNAL_SERVICE_EVENT_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ExternalServiceEventClient) List(opts *ListOpts) (*ExternalServiceEventCollection, error) {
+	resp := &ExternalServiceEventCollection{}
+	err := c.rancherClient.doList(EXTERNAL_SERVICE_EVENT_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ExternalServiceEventClient) ById(id string) (*ExternalServiceEvent, error) {
+	resp := &ExternalServiceEvent{}
+	err := c.rancherClient.doById(EXTERNAL_SERVICE_EVENT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ExternalServiceEventClient) Delete(container *ExternalServiceEvent) error {
+	return c.rancherClient.doResourceDelete(EXTERNAL_SERVICE_EVENT_TYPE, &container.Resource)
+}
+
+func (c *ExternalServiceEventClient) ActionCreate(resource *ExternalServiceEvent) (*ExternalEvent, error) {
+
+	resp := &ExternalEvent{}
+
+	err := c.rancherClient.doAction(EXTERNAL_SERVICE_EVENT_TYPE, "create", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *ExternalServiceEventClient) ActionRemove(resource *ExternalServiceEvent) (*ExternalEvent, error) {
+
+	resp := &ExternalEvent{}
+
+	err := c.rancherClient.doAction(EXTERNAL_SERVICE_EVENT_TYPE, "remove", &resource.Resource, nil, resp)
+
+	return resp, err
+}

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_external_storage_pool_event.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_external_storage_pool_event.go
@@ -84,6 +84,11 @@ func (c *ExternalStoragePoolEventClient) List(opts *ListOpts) (*ExternalStorageP
 func (c *ExternalStoragePoolEventClient) ById(id string) (*ExternalStoragePoolEvent, error) {
 	resp := &ExternalStoragePoolEvent{}
 	err := c.rancherClient.doById(EXTERNAL_STORAGE_POOL_EVENT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_external_volume_event.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_external_volume_event.go
@@ -84,6 +84,11 @@ func (c *ExternalVolumeEventClient) List(opts *ListOpts) (*ExternalVolumeEventCo
 func (c *ExternalVolumeEventClient) ById(id string) (*ExternalVolumeEvent, error) {
 	resp := &ExternalVolumeEvent{}
 	err := c.rancherClient.doById(EXTERNAL_VOLUME_EVENT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_field_documentation.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_field_documentation.go
@@ -54,6 +54,11 @@ func (c *FieldDocumentationClient) List(opts *ListOpts) (*FieldDocumentationColl
 func (c *FieldDocumentationClient) ById(id string) (*FieldDocumentation, error) {
 	resp := &FieldDocumentation{}
 	err := c.rancherClient.doById(FIELD_DOCUMENTATION_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_githubconfig.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_githubconfig.go
@@ -68,6 +68,11 @@ func (c *GithubconfigClient) List(opts *ListOpts) (*GithubconfigCollection, erro
 func (c *GithubconfigClient) ById(id string) (*Githubconfig, error) {
 	resp := &Githubconfig{}
 	err := c.rancherClient.doById(GITHUBCONFIG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_global_load_balancer.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_global_load_balancer.go
@@ -90,6 +90,11 @@ func (c *GlobalLoadBalancerClient) List(opts *ListOpts) (*GlobalLoadBalancerColl
 func (c *GlobalLoadBalancerClient) ById(id string) (*GlobalLoadBalancer, error) {
 	resp := &GlobalLoadBalancer{}
 	err := c.rancherClient.doById(GLOBAL_LOAD_BALANCER_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_global_load_balancer_health_check.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_global_load_balancer_health_check.go
@@ -54,6 +54,11 @@ func (c *GlobalLoadBalancerHealthCheckClient) List(opts *ListOpts) (*GlobalLoadB
 func (c *GlobalLoadBalancerHealthCheckClient) ById(id string) (*GlobalLoadBalancerHealthCheck, error) {
 	resp := &GlobalLoadBalancerHealthCheck{}
 	err := c.rancherClient.doById(GLOBAL_LOAD_BALANCER_HEALTH_CHECK_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_global_load_balancer_policy.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_global_load_balancer_policy.go
@@ -54,6 +54,11 @@ func (c *GlobalLoadBalancerPolicyClient) List(opts *ListOpts) (*GlobalLoadBalanc
 func (c *GlobalLoadBalancerPolicyClient) ById(id string) (*GlobalLoadBalancerPolicy, error) {
 	resp := &GlobalLoadBalancerPolicy{}
 	err := c.rancherClient.doById(GLOBAL_LOAD_BALANCER_POLICY_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_host.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_host.go
@@ -70,6 +70,8 @@ type HostOperations interface {
 
 	ActionDeactivate(*Host) (*Host, error)
 
+	ActionDockersocket(*Host) (*HostAccess, error)
+
 	ActionPurge(*Host) (*Host, error)
 
 	ActionRemove(*Host) (*Host, error)
@@ -106,6 +108,11 @@ func (c *HostClient) List(opts *ListOpts) (*HostCollection, error) {
 func (c *HostClient) ById(id string) (*Host, error) {
 	resp := &Host{}
 	err := c.rancherClient.doById(HOST_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 
@@ -136,6 +143,15 @@ func (c *HostClient) ActionDeactivate(resource *Host) (*Host, error) {
 	resp := &Host{}
 
 	err := c.rancherClient.doAction(HOST_TYPE, "deactivate", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
+func (c *HostClient) ActionDockersocket(resource *Host) (*HostAccess, error) {
+
+	resp := &HostAccess{}
+
+	err := c.rancherClient.doAction(HOST_TYPE, "dockersocket", &resource.Resource, nil, resp)
 
 	return resp, err
 }

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_host_access.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_host_access.go
@@ -56,6 +56,11 @@ func (c *HostAccessClient) List(opts *ListOpts) (*HostAccessCollection, error) {
 func (c *HostAccessClient) ById(id string) (*HostAccess, error) {
 	resp := &HostAccess{}
 	err := c.rancherClient.doById(HOST_ACCESS_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_host_api_proxy_token.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_host_api_proxy_token.go
@@ -58,6 +58,11 @@ func (c *HostApiProxyTokenClient) List(opts *ListOpts) (*HostApiProxyTokenCollec
 func (c *HostApiProxyTokenClient) ById(id string) (*HostApiProxyToken, error) {
 	resp := &HostApiProxyToken{}
 	err := c.rancherClient.doById(HOST_API_PROXY_TOKEN_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_identity.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_identity.go
@@ -70,6 +70,11 @@ func (c *IdentityClient) List(opts *ListOpts) (*IdentityCollection, error) {
 func (c *IdentityClient) ById(id string) (*Identity, error) {
 	resp := &Identity{}
 	err := c.rancherClient.doById(IDENTITY_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_image.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_image.go
@@ -92,6 +92,11 @@ func (c *ImageClient) List(opts *ListOpts) (*ImageCollection, error) {
 func (c *ImageClient) ById(id string) (*Image, error) {
 	resp := &Image{}
 	err := c.rancherClient.doById(IMAGE_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_in_service_upgrade_strategy.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_in_service_upgrade_strategy.go
@@ -1,0 +1,79 @@
+package client
+
+const (
+	IN_SERVICE_UPGRADE_STRATEGY_TYPE = "inServiceUpgradeStrategy"
+)
+
+type InServiceUpgradeStrategy struct {
+	Resource
+
+	BatchSize int64 `json:"batchSize,omitempty" yaml:"batch_size,omitempty"`
+
+	IntervalMillis int64 `json:"intervalMillis,omitempty" yaml:"interval_millis,omitempty"`
+
+	LaunchConfig *LaunchConfig `json:"launchConfig,omitempty" yaml:"launch_config,omitempty"`
+
+	PreviousLaunchConfig *LaunchConfig `json:"previousLaunchConfig,omitempty" yaml:"previous_launch_config,omitempty"`
+
+	PreviousSecondaryLaunchConfigs []interface{} `json:"previousSecondaryLaunchConfigs,omitempty" yaml:"previous_secondary_launch_configs,omitempty"`
+
+	SecondaryLaunchConfigs []interface{} `json:"secondaryLaunchConfigs,omitempty" yaml:"secondary_launch_configs,omitempty"`
+
+	StartFirst bool `json:"startFirst,omitempty" yaml:"start_first,omitempty"`
+}
+
+type InServiceUpgradeStrategyCollection struct {
+	Collection
+	Data []InServiceUpgradeStrategy `json:"data,omitempty"`
+}
+
+type InServiceUpgradeStrategyClient struct {
+	rancherClient *RancherClient
+}
+
+type InServiceUpgradeStrategyOperations interface {
+	List(opts *ListOpts) (*InServiceUpgradeStrategyCollection, error)
+	Create(opts *InServiceUpgradeStrategy) (*InServiceUpgradeStrategy, error)
+	Update(existing *InServiceUpgradeStrategy, updates interface{}) (*InServiceUpgradeStrategy, error)
+	ById(id string) (*InServiceUpgradeStrategy, error)
+	Delete(container *InServiceUpgradeStrategy) error
+}
+
+func newInServiceUpgradeStrategyClient(rancherClient *RancherClient) *InServiceUpgradeStrategyClient {
+	return &InServiceUpgradeStrategyClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *InServiceUpgradeStrategyClient) Create(container *InServiceUpgradeStrategy) (*InServiceUpgradeStrategy, error) {
+	resp := &InServiceUpgradeStrategy{}
+	err := c.rancherClient.doCreate(IN_SERVICE_UPGRADE_STRATEGY_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *InServiceUpgradeStrategyClient) Update(existing *InServiceUpgradeStrategy, updates interface{}) (*InServiceUpgradeStrategy, error) {
+	resp := &InServiceUpgradeStrategy{}
+	err := c.rancherClient.doUpdate(IN_SERVICE_UPGRADE_STRATEGY_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *InServiceUpgradeStrategyClient) List(opts *ListOpts) (*InServiceUpgradeStrategyCollection, error) {
+	resp := &InServiceUpgradeStrategyCollection{}
+	err := c.rancherClient.doList(IN_SERVICE_UPGRADE_STRATEGY_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *InServiceUpgradeStrategyClient) ById(id string) (*InServiceUpgradeStrategy, error) {
+	resp := &InServiceUpgradeStrategy{}
+	err := c.rancherClient.doById(IN_SERVICE_UPGRADE_STRATEGY_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *InServiceUpgradeStrategyClient) Delete(container *InServiceUpgradeStrategy) error {
+	return c.rancherClient.doResourceDelete(IN_SERVICE_UPGRADE_STRATEGY_TYPE, &container.Resource)
+}

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_instance.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_instance.go
@@ -108,6 +108,11 @@ func (c *InstanceClient) List(opts *ListOpts) (*InstanceCollection, error) {
 func (c *InstanceClient) ById(id string) (*Instance, error) {
 	resp := &Instance{}
 	err := c.rancherClient.doById(INSTANCE_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_instance_console.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_instance_console.go
@@ -58,6 +58,11 @@ func (c *InstanceConsoleClient) List(opts *ListOpts) (*InstanceConsoleCollection
 func (c *InstanceConsoleClient) ById(id string) (*InstanceConsole, error) {
 	resp := &InstanceConsole{}
 	err := c.rancherClient.doById(INSTANCE_CONSOLE_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_instance_console_input.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_instance_console_input.go
@@ -52,6 +52,11 @@ func (c *InstanceConsoleInputClient) List(opts *ListOpts) (*InstanceConsoleInput
 func (c *InstanceConsoleInputClient) ById(id string) (*InstanceConsoleInput, error) {
 	resp := &InstanceConsoleInput{}
 	err := c.rancherClient.doById(INSTANCE_CONSOLE_INPUT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_instance_health_check.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_instance_health_check.go
@@ -66,6 +66,11 @@ func (c *InstanceHealthCheckClient) List(opts *ListOpts) (*InstanceHealthCheckCo
 func (c *InstanceHealthCheckClient) ById(id string) (*InstanceHealthCheck, error) {
 	resp := &InstanceHealthCheck{}
 	err := c.rancherClient.doById(INSTANCE_HEALTH_CHECK_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_instance_link.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_instance_link.go
@@ -100,6 +100,11 @@ func (c *InstanceLinkClient) List(opts *ListOpts) (*InstanceLinkCollection, erro
 func (c *InstanceLinkClient) ById(id string) (*InstanceLink, error) {
 	resp := &InstanceLink{}
 	err := c.rancherClient.doById(INSTANCE_LINK_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_instance_stop.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_instance_stop.go
@@ -58,6 +58,11 @@ func (c *InstanceStopClient) List(opts *ListOpts) (*InstanceStopCollection, erro
 func (c *InstanceStopClient) ById(id string) (*InstanceStop, error) {
 	resp := &InstanceStop{}
 	err := c.rancherClient.doById(INSTANCE_STOP_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_ip_address.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_ip_address.go
@@ -98,6 +98,11 @@ func (c *IpAddressClient) List(opts *ListOpts) (*IpAddressCollection, error) {
 func (c *IpAddressClient) ById(id string) (*IpAddress, error) {
 	resp := &IpAddress{}
 	err := c.rancherClient.doById(IP_ADDRESS_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_ip_address_associate_input.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_ip_address_associate_input.go
@@ -54,6 +54,11 @@ func (c *IpAddressAssociateInputClient) List(opts *ListOpts) (*IpAddressAssociat
 func (c *IpAddressAssociateInputClient) ById(id string) (*IpAddressAssociateInput, error) {
 	resp := &IpAddressAssociateInput{}
 	err := c.rancherClient.doById(IP_ADDRESS_ASSOCIATE_INPUT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_label.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_label.go
@@ -86,6 +86,11 @@ func (c *LabelClient) List(opts *ListOpts) (*LabelCollection, error) {
 func (c *LabelClient) ById(id string) (*Label, error) {
 	resp := &Label{}
 	err := c.rancherClient.doById(LABEL_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_launch_config.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_launch_config.go
@@ -117,9 +117,9 @@ type LaunchConfig struct {
 
 	RequestedHostId string `json:"requestedHostId,omitempty" yaml:"requested_host_id,omitempty"`
 
-	RestartPolicy *RestartPolicy `json:"restartPolicy,omitempty" yaml:"restart_policy,omitempty"`
-
 	SecurityOpt []string `json:"securityOpt,omitempty" yaml:"security_opt,omitempty"`
+
+	StartCount int64 `json:"startCount,omitempty" yaml:"start_count,omitempty"`
 
 	StartOnCreate bool `json:"startOnCreate,omitempty" yaml:"start_on_create,omitempty"`
 
@@ -228,6 +228,11 @@ func (c *LaunchConfigClient) List(opts *ListOpts) (*LaunchConfigCollection, erro
 func (c *LaunchConfigClient) ById(id string) (*LaunchConfig, error) {
 	resp := &LaunchConfig{}
 	err := c.rancherClient.doById(LAUNCH_CONFIG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_ldapconfig.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_ldapconfig.go
@@ -90,6 +90,11 @@ func (c *LdapconfigClient) List(opts *ListOpts) (*LdapconfigCollection, error) {
 func (c *LdapconfigClient) ById(id string) (*Ldapconfig, error) {
 	resp := &Ldapconfig{}
 	err := c.rancherClient.doById(LDAPCONFIG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_load_balancer.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_load_balancer.go
@@ -112,6 +112,11 @@ func (c *LoadBalancerClient) List(opts *ListOpts) (*LoadBalancerCollection, erro
 func (c *LoadBalancerClient) ById(id string) (*LoadBalancer, error) {
 	resp := &LoadBalancer{}
 	err := c.rancherClient.doById(LOAD_BALANCER_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_load_balancer_app_cookie_stickiness_policy.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_load_balancer_app_cookie_stickiness_policy.go
@@ -66,6 +66,11 @@ func (c *LoadBalancerAppCookieStickinessPolicyClient) List(opts *ListOpts) (*Loa
 func (c *LoadBalancerAppCookieStickinessPolicyClient) ById(id string) (*LoadBalancerAppCookieStickinessPolicy, error) {
 	resp := &LoadBalancerAppCookieStickinessPolicy{}
 	err := c.rancherClient.doById(LOAD_BALANCER_APP_COOKIE_STICKINESS_POLICY_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_load_balancer_config.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_load_balancer_config.go
@@ -98,6 +98,11 @@ func (c *LoadBalancerConfigClient) List(opts *ListOpts) (*LoadBalancerConfigColl
 func (c *LoadBalancerConfigClient) ById(id string) (*LoadBalancerConfig, error) {
 	resp := &LoadBalancerConfig{}
 	err := c.rancherClient.doById(LOAD_BALANCER_CONFIG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_load_balancer_config_listener_map.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_load_balancer_config_listener_map.go
@@ -86,6 +86,11 @@ func (c *LoadBalancerConfigListenerMapClient) List(opts *ListOpts) (*LoadBalance
 func (c *LoadBalancerConfigListenerMapClient) ById(id string) (*LoadBalancerConfigListenerMap, error) {
 	resp := &LoadBalancerConfigListenerMap{}
 	err := c.rancherClient.doById(LOAD_BALANCER_CONFIG_LISTENER_MAP_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_load_balancer_cookie_stickiness_policy.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_load_balancer_cookie_stickiness_policy.go
@@ -66,6 +66,11 @@ func (c *LoadBalancerCookieStickinessPolicyClient) List(opts *ListOpts) (*LoadBa
 func (c *LoadBalancerCookieStickinessPolicyClient) ById(id string) (*LoadBalancerCookieStickinessPolicy, error) {
 	resp := &LoadBalancerCookieStickinessPolicy{}
 	err := c.rancherClient.doById(LOAD_BALANCER_COOKIE_STICKINESS_POLICY_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_load_balancer_health_check.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_load_balancer_health_check.go
@@ -66,6 +66,11 @@ func (c *LoadBalancerHealthCheckClient) List(opts *ListOpts) (*LoadBalancerHealt
 func (c *LoadBalancerHealthCheckClient) ById(id string) (*LoadBalancerHealthCheck, error) {
 	resp := &LoadBalancerHealthCheck{}
 	err := c.rancherClient.doById(LOAD_BALANCER_HEALTH_CHECK_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_load_balancer_host_map.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_load_balancer_host_map.go
@@ -76,6 +76,11 @@ func (c *LoadBalancerHostMapClient) List(opts *ListOpts) (*LoadBalancerHostMapCo
 func (c *LoadBalancerHostMapClient) ById(id string) (*LoadBalancerHostMap, error) {
 	resp := &LoadBalancerHostMap{}
 	err := c.rancherClient.doById(LOAD_BALANCER_HOST_MAP_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_load_balancer_listener.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_load_balancer_listener.go
@@ -96,6 +96,11 @@ func (c *LoadBalancerListenerClient) List(opts *ListOpts) (*LoadBalancerListener
 func (c *LoadBalancerListenerClient) ById(id string) (*LoadBalancerListener, error) {
 	resp := &LoadBalancerListener{}
 	err := c.rancherClient.doById(LOAD_BALANCER_LISTENER_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_load_balancer_service.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_load_balancer_service.go
@@ -21,9 +21,13 @@ type LoadBalancerService struct {
 
 	EnvironmentId string `json:"environmentId,omitempty" yaml:"environment_id,omitempty"`
 
+	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
+
+	Fqdn string `json:"fqdn,omitempty" yaml:"fqdn,omitempty"`
+
 	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
 
-	LaunchConfig LaunchConfig `json:"launchConfig,omitempty" yaml:"launch_config,omitempty"`
+	LaunchConfig *LaunchConfig `json:"launchConfig,omitempty" yaml:"launch_config,omitempty"`
 
 	LoadBalancerConfig *LoadBalancerConfig `json:"loadBalancerConfig,omitempty" yaml:"load_balancer_config,omitempty"`
 
@@ -74,15 +78,21 @@ type LoadBalancerServiceOperations interface {
 
 	ActionAddservicelink(*LoadBalancerService, *AddRemoveLoadBalancerServiceLinkInput) (*Service, error)
 
+	ActionCancelrollback(*LoadBalancerService) (*Service, error)
+
 	ActionCancelupgrade(*LoadBalancerService) (*Service, error)
 
 	ActionCreate(*LoadBalancerService) (*Service, error)
 
 	ActionDeactivate(*LoadBalancerService) (*Service, error)
 
+	ActionFinishupgrade(*LoadBalancerService) (*Service, error)
+
 	ActionRemove(*LoadBalancerService) (*Service, error)
 
 	ActionRemoveservicelink(*LoadBalancerService, *AddRemoveLoadBalancerServiceLinkInput) (*Service, error)
+
+	ActionRollback(*LoadBalancerService) (*Service, error)
 
 	ActionSetservicelinks(*LoadBalancerService, *SetLoadBalancerServiceLinksInput) (*Service, error)
 
@@ -118,6 +128,11 @@ func (c *LoadBalancerServiceClient) List(opts *ListOpts) (*LoadBalancerServiceCo
 func (c *LoadBalancerServiceClient) ById(id string) (*LoadBalancerService, error) {
 	resp := &LoadBalancerService{}
 	err := c.rancherClient.doById(LOAD_BALANCER_SERVICE_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 
@@ -139,6 +154,15 @@ func (c *LoadBalancerServiceClient) ActionAddservicelink(resource *LoadBalancerS
 	resp := &Service{}
 
 	err := c.rancherClient.doAction(LOAD_BALANCER_SERVICE_TYPE, "addservicelink", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *LoadBalancerServiceClient) ActionCancelrollback(resource *LoadBalancerService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(LOAD_BALANCER_SERVICE_TYPE, "cancelrollback", &resource.Resource, nil, resp)
 
 	return resp, err
 }
@@ -170,6 +194,15 @@ func (c *LoadBalancerServiceClient) ActionDeactivate(resource *LoadBalancerServi
 	return resp, err
 }
 
+func (c *LoadBalancerServiceClient) ActionFinishupgrade(resource *LoadBalancerService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(LOAD_BALANCER_SERVICE_TYPE, "finishupgrade", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
 func (c *LoadBalancerServiceClient) ActionRemove(resource *LoadBalancerService) (*Service, error) {
 
 	resp := &Service{}
@@ -184,6 +217,15 @@ func (c *LoadBalancerServiceClient) ActionRemoveservicelink(resource *LoadBalanc
 	resp := &Service{}
 
 	err := c.rancherClient.doAction(LOAD_BALANCER_SERVICE_TYPE, "removeservicelink", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *LoadBalancerServiceClient) ActionRollback(resource *LoadBalancerService) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(LOAD_BALANCER_SERVICE_TYPE, "rollback", &resource.Resource, nil, resp)
 
 	return resp, err
 }

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_load_balancer_service_link.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_load_balancer_service_link.go
@@ -56,6 +56,11 @@ func (c *LoadBalancerServiceLinkClient) List(opts *ListOpts) (*LoadBalancerServi
 func (c *LoadBalancerServiceLinkClient) ById(id string) (*LoadBalancerServiceLink, error) {
 	resp := &LoadBalancerServiceLink{}
 	err := c.rancherClient.doById(LOAD_BALANCER_SERVICE_LINK_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_load_balancer_target.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_load_balancer_target.go
@@ -92,6 +92,11 @@ func (c *LoadBalancerTargetClient) List(opts *ListOpts) (*LoadBalancerTargetColl
 func (c *LoadBalancerTargetClient) ById(id string) (*LoadBalancerTarget, error) {
 	resp := &LoadBalancerTarget{}
 	err := c.rancherClient.doById(LOAD_BALANCER_TARGET_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_local_auth_config.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_local_auth_config.go
@@ -62,6 +62,11 @@ func (c *LocalAuthConfigClient) List(opts *ListOpts) (*LocalAuthConfigCollection
 func (c *LocalAuthConfigClient) ById(id string) (*LocalAuthConfig, error) {
 	resp := &LocalAuthConfig{}
 	err := c.rancherClient.doById(LOCAL_AUTH_CONFIG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_log_config.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_log_config.go
@@ -56,6 +56,11 @@ func (c *LogConfigClient) List(opts *ListOpts) (*LogConfigCollection, error) {
 func (c *LogConfigClient) ById(id string) (*LogConfig, error) {
 	resp := &LogConfig{}
 	err := c.rancherClient.doById(LOG_CONFIG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_machine.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_machine.go
@@ -59,6 +59,8 @@ type Machine struct {
 
 	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
 
+	UbiquityConfig *UbiquityConfig `json:"ubiquityConfig,omitempty" yaml:"ubiquity_config,omitempty"`
+
 	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
 
 	VirtualboxConfig *VirtualboxConfig `json:"virtualboxConfig,omitempty" yaml:"virtualbox_config,omitempty"`
@@ -122,6 +124,11 @@ func (c *MachineClient) List(opts *ListOpts) (*MachineCollection, error) {
 func (c *MachineClient) ById(id string) (*Machine, error) {
 	resp := &Machine{}
 	err := c.rancherClient.doById(MACHINE_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_mount.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_mount.go
@@ -100,6 +100,11 @@ func (c *MountClient) List(opts *ListOpts) (*MountCollection, error) {
 func (c *MountClient) ById(id string) (*Mount, error) {
 	resp := &Mount{}
 	err := c.rancherClient.doById(MOUNT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_network.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_network.go
@@ -92,6 +92,11 @@ func (c *NetworkClient) List(opts *ListOpts) (*NetworkCollection, error) {
 func (c *NetworkClient) ById(id string) (*Network, error) {
 	resp := &Network{}
 	err := c.rancherClient.doById(NETWORK_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_openstack_config.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_openstack_config.go
@@ -94,6 +94,11 @@ func (c *OpenstackConfigClient) List(opts *ListOpts) (*OpenstackConfigCollection
 func (c *OpenstackConfigClient) ById(id string) (*OpenstackConfig, error) {
 	resp := &OpenstackConfig{}
 	err := c.rancherClient.doById(OPENSTACK_CONFIG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_packet_config.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_packet_config.go
@@ -64,6 +64,11 @@ func (c *PacketConfigClient) List(opts *ListOpts) (*PacketConfigCollection, erro
 func (c *PacketConfigClient) ById(id string) (*PacketConfig, error) {
 	resp := &PacketConfig{}
 	err := c.rancherClient.doById(PACKET_CONFIG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_password.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_password.go
@@ -96,6 +96,11 @@ func (c *PasswordClient) List(opts *ListOpts) (*PasswordCollection, error) {
 func (c *PasswordClient) ById(id string) (*Password, error) {
 	resp := &Password{}
 	err := c.rancherClient.doById(PASSWORD_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_physical_host.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_physical_host.go
@@ -88,6 +88,11 @@ func (c *PhysicalHostClient) List(opts *ListOpts) (*PhysicalHostCollection, erro
 func (c *PhysicalHostClient) ById(id string) (*PhysicalHost, error) {
 	resp := &PhysicalHost{}
 	err := c.rancherClient.doById(PHYSICAL_HOST_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_port.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_port.go
@@ -104,6 +104,11 @@ func (c *PortClient) List(opts *ListOpts) (*PortCollection, error) {
 func (c *PortClient) ById(id string) (*Port, error) {
 	resp := &Port{}
 	err := c.rancherClient.doById(PORT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_process_definition.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_process_definition.go
@@ -66,6 +66,11 @@ func (c *ProcessDefinitionClient) List(opts *ListOpts) (*ProcessDefinitionCollec
 func (c *ProcessDefinitionClient) ById(id string) (*ProcessDefinition, error) {
 	resp := &ProcessDefinition{}
 	err := c.rancherClient.doById(PROCESS_DEFINITION_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_process_execution.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_process_execution.go
@@ -58,6 +58,11 @@ func (c *ProcessExecutionClient) List(opts *ListOpts) (*ProcessExecutionCollecti
 func (c *ProcessExecutionClient) ById(id string) (*ProcessExecution, error) {
 	resp := &ProcessExecution{}
 	err := c.rancherClient.doById(PROCESS_EXECUTION_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_process_instance.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_process_instance.go
@@ -76,6 +76,11 @@ func (c *ProcessInstanceClient) List(opts *ListOpts) (*ProcessInstanceCollection
 func (c *ProcessInstanceClient) ById(id string) (*ProcessInstance, error) {
 	resp := &ProcessInstance{}
 	err := c.rancherClient.doById(PROCESS_INSTANCE_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_project.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_project.go
@@ -94,6 +94,11 @@ func (c *ProjectClient) List(opts *ListOpts) (*ProjectCollection, error) {
 func (c *ProjectClient) ById(id string) (*Project, error) {
 	resp := &Project{}
 	err := c.rancherClient.doById(PROJECT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_project_member.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_project_member.go
@@ -98,6 +98,11 @@ func (c *ProjectMemberClient) List(opts *ListOpts) (*ProjectMemberCollection, er
 func (c *ProjectMemberClient) ById(id string) (*ProjectMember, error) {
 	resp := &ProjectMember{}
 	err := c.rancherClient.doById(PROJECT_MEMBER_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_publish.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_publish.go
@@ -74,6 +74,11 @@ func (c *PublishClient) List(opts *ListOpts) (*PublishCollection, error) {
 func (c *PublishClient) ById(id string) (*Publish, error) {
 	resp := &Publish{}
 	err := c.rancherClient.doById(PUBLISH_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_pull_task.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_pull_task.go
@@ -86,6 +86,11 @@ func (c *PullTaskClient) List(opts *ListOpts) (*PullTaskCollection, error) {
 func (c *PullTaskClient) ById(id string) (*PullTask, error) {
 	resp := &PullTask{}
 	err := c.rancherClient.doById(PULL_TASK_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_rackspace_config.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_rackspace_config.go
@@ -70,6 +70,11 @@ func (c *RackspaceConfigClient) List(opts *ListOpts) (*RackspaceConfigCollection
 func (c *RackspaceConfigClient) ById(id string) (*RackspaceConfig, error) {
 	resp := &RackspaceConfig{}
 	err := c.rancherClient.doById(RACKSPACE_CONFIG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_register.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_register.go
@@ -86,6 +86,11 @@ func (c *RegisterClient) List(opts *ListOpts) (*RegisterCollection, error) {
 func (c *RegisterClient) ById(id string) (*Register, error) {
 	resp := &Register{}
 	err := c.rancherClient.doById(REGISTER_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_registration_token.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_registration_token.go
@@ -98,6 +98,11 @@ func (c *RegistrationTokenClient) List(opts *ListOpts) (*RegistrationTokenCollec
 func (c *RegistrationTokenClient) ById(id string) (*RegistrationToken, error) {
 	resp := &RegistrationToken{}
 	err := c.rancherClient.doById(REGISTRATION_TOKEN_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_registry.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_registry.go
@@ -15,6 +15,8 @@ type Registry struct {
 
 	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 
+	DriverName string `json:"driverName,omitempty" yaml:"driver_name,omitempty"`
+
 	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
 
 	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
@@ -96,6 +98,11 @@ func (c *RegistryClient) List(opts *ListOpts) (*RegistryCollection, error) {
 func (c *RegistryClient) ById(id string) (*Registry, error) {
 	resp := &Registry{}
 	err := c.rancherClient.doById(REGISTRY_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_registry_credential.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_registry_credential.go
@@ -98,6 +98,11 @@ func (c *RegistryCredentialClient) List(opts *ListOpts) (*RegistryCredentialColl
 func (c *RegistryCredentialClient) ById(id string) (*RegistryCredential, error) {
 	resp := &RegistryCredential{}
 	err := c.rancherClient.doById(REGISTRY_CREDENTIAL_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_remove_load_balancer_input.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_remove_load_balancer_input.go
@@ -54,6 +54,11 @@ func (c *RemoveLoadBalancerInputClient) List(opts *ListOpts) (*RemoveLoadBalance
 func (c *RemoveLoadBalancerInputClient) ById(id string) (*RemoveLoadBalancerInput, error) {
 	resp := &RemoveLoadBalancerInput{}
 	err := c.rancherClient.doById(REMOVE_LOAD_BALANCER_INPUT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_resource_definition.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_resource_definition.go
@@ -54,6 +54,11 @@ func (c *ResourceDefinitionClient) List(opts *ListOpts) (*ResourceDefinitionColl
 func (c *ResourceDefinitionClient) ById(id string) (*ResourceDefinition, error) {
 	resp := &ResourceDefinition{}
 	err := c.rancherClient.doById(RESOURCE_DEFINITION_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_restart_policy.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_restart_policy.go
@@ -56,6 +56,11 @@ func (c *RestartPolicyClient) List(opts *ListOpts) (*RestartPolicyCollection, er
 func (c *RestartPolicyClient) ById(id string) (*RestartPolicy, error) {
 	resp := &RestartPolicy{}
 	err := c.rancherClient.doById(RESTART_POLICY_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_secondary_launch_config.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_secondary_launch_config.go
@@ -119,9 +119,9 @@ type SecondaryLaunchConfig struct {
 
 	RequestedHostId string `json:"requestedHostId,omitempty" yaml:"requested_host_id,omitempty"`
 
-	RestartPolicy *RestartPolicy `json:"restartPolicy,omitempty" yaml:"restart_policy,omitempty"`
-
 	SecurityOpt []string `json:"securityOpt,omitempty" yaml:"security_opt,omitempty"`
+
+	StartCount int64 `json:"startCount,omitempty" yaml:"start_count,omitempty"`
 
 	StartOnCreate bool `json:"startOnCreate,omitempty" yaml:"start_on_create,omitempty"`
 
@@ -230,6 +230,11 @@ func (c *SecondaryLaunchConfigClient) List(opts *ListOpts) (*SecondaryLaunchConf
 func (c *SecondaryLaunchConfigClient) ById(id string) (*SecondaryLaunchConfig, error) {
 	resp := &SecondaryLaunchConfig{}
 	err := c.rancherClient.doById(SECONDARY_LAUNCH_CONFIG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_service.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_service.go
@@ -19,9 +19,13 @@ type Service struct {
 
 	EnvironmentId string `json:"environmentId,omitempty" yaml:"environment_id,omitempty"`
 
+	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
+
+	Fqdn string `json:"fqdn,omitempty" yaml:"fqdn,omitempty"`
+
 	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
 
-	LaunchConfig LaunchConfig `json:"launchConfig,omitempty" yaml:"launch_config,omitempty"`
+	LaunchConfig *LaunchConfig `json:"launchConfig,omitempty" yaml:"launch_config,omitempty"`
 
 	Metadata map[string]interface{} `json:"metadata,omitempty" yaml:"metadata,omitempty"`
 
@@ -38,6 +42,8 @@ type Service struct {
 	SelectorContainer string `json:"selectorContainer,omitempty" yaml:"selector_container,omitempty"`
 
 	SelectorLink string `json:"selectorLink,omitempty" yaml:"selector_link,omitempty"`
+
+	ServiceSchemas map[string]interface{} `json:"serviceSchemas,omitempty" yaml:"service_schemas,omitempty"`
 
 	State string `json:"state,omitempty" yaml:"state,omitempty"`
 
@@ -74,15 +80,21 @@ type ServiceOperations interface {
 
 	ActionAddservicelink(*Service, *AddRemoveServiceLinkInput) (*Service, error)
 
+	ActionCancelrollback(*Service) (*Service, error)
+
 	ActionCancelupgrade(*Service) (*Service, error)
 
 	ActionCreate(*Service) (*Service, error)
 
 	ActionDeactivate(*Service) (*Service, error)
 
+	ActionFinishupgrade(*Service) (*Service, error)
+
 	ActionRemove(*Service) (*Service, error)
 
 	ActionRemoveservicelink(*Service, *AddRemoveServiceLinkInput) (*Service, error)
+
+	ActionRollback(*Service) (*Service, error)
 
 	ActionSetservicelinks(*Service, *SetServiceLinksInput) (*Service, error)
 
@@ -118,6 +130,11 @@ func (c *ServiceClient) List(opts *ListOpts) (*ServiceCollection, error) {
 func (c *ServiceClient) ById(id string) (*Service, error) {
 	resp := &Service{}
 	err := c.rancherClient.doById(SERVICE_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 
@@ -139,6 +156,15 @@ func (c *ServiceClient) ActionAddservicelink(resource *Service, input *AddRemove
 	resp := &Service{}
 
 	err := c.rancherClient.doAction(SERVICE_TYPE, "addservicelink", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *ServiceClient) ActionCancelrollback(resource *Service) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(SERVICE_TYPE, "cancelrollback", &resource.Resource, nil, resp)
 
 	return resp, err
 }
@@ -170,6 +196,15 @@ func (c *ServiceClient) ActionDeactivate(resource *Service) (*Service, error) {
 	return resp, err
 }
 
+func (c *ServiceClient) ActionFinishupgrade(resource *Service) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(SERVICE_TYPE, "finishupgrade", &resource.Resource, nil, resp)
+
+	return resp, err
+}
+
 func (c *ServiceClient) ActionRemove(resource *Service) (*Service, error) {
 
 	resp := &Service{}
@@ -184,6 +219,15 @@ func (c *ServiceClient) ActionRemoveservicelink(resource *Service, input *AddRem
 	resp := &Service{}
 
 	err := c.rancherClient.doAction(SERVICE_TYPE, "removeservicelink", &resource.Resource, input, resp)
+
+	return resp, err
+}
+
+func (c *ServiceClient) ActionRollback(resource *Service) (*Service, error) {
+
+	resp := &Service{}
+
+	err := c.rancherClient.doAction(SERVICE_TYPE, "rollback", &resource.Resource, nil, resp)
 
 	return resp, err
 }

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_service_consume_map.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_service_consume_map.go
@@ -90,6 +90,11 @@ func (c *ServiceConsumeMapClient) List(opts *ListOpts) (*ServiceConsumeMapCollec
 func (c *ServiceConsumeMapClient) ById(id string) (*ServiceConsumeMap, error) {
 	resp := &ServiceConsumeMap{}
 	err := c.rancherClient.doById(SERVICE_CONSUME_MAP_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_service_event.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_service_event.go
@@ -92,6 +92,11 @@ func (c *ServiceEventClient) List(opts *ListOpts) (*ServiceEventCollection, erro
 func (c *ServiceEventClient) ById(id string) (*ServiceEvent, error) {
 	resp := &ServiceEvent{}
 	err := c.rancherClient.doById(SERVICE_EVENT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_service_expose_map.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_service_expose_map.go
@@ -90,6 +90,11 @@ func (c *ServiceExposeMapClient) List(opts *ListOpts) (*ServiceExposeMapCollecti
 func (c *ServiceExposeMapClient) ById(id string) (*ServiceExposeMap, error) {
 	resp := &ServiceExposeMap{}
 	err := c.rancherClient.doById(SERVICE_EXPOSE_MAP_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_service_link.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_service_link.go
@@ -56,6 +56,11 @@ func (c *ServiceLinkClient) List(opts *ListOpts) (*ServiceLinkCollection, error)
 func (c *ServiceLinkClient) ById(id string) (*ServiceLink, error) {
 	resp := &ServiceLink{}
 	err := c.rancherClient.doById(SERVICE_LINK_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_service_upgrade.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_service_upgrade.go
@@ -7,19 +7,9 @@ const (
 type ServiceUpgrade struct {
 	Resource
 
-	BatchSize int64 `json:"batchSize,omitempty" yaml:"batch_size,omitempty"`
+	InServiceStrategy *InServiceUpgradeStrategy `json:"inServiceStrategy,omitempty" yaml:"in_service_strategy,omitempty"`
 
-	FinalScale int64 `json:"finalScale,omitempty" yaml:"final_scale,omitempty"`
-
-	IntervalMillis int64 `json:"intervalMillis,omitempty" yaml:"interval_millis,omitempty"`
-
-	LaunchConfig *LaunchConfig `json:"launchConfig,omitempty" yaml:"launch_config,omitempty"`
-
-	SecondaryLaunchConfigs []interface{} `json:"secondaryLaunchConfigs,omitempty" yaml:"secondary_launch_configs,omitempty"`
-
-	ToServiceId string `json:"toServiceId,omitempty" yaml:"to_service_id,omitempty"`
-
-	UpdateLinks bool `json:"updateLinks,omitempty" yaml:"update_links,omitempty"`
+	ToServiceStrategy *ToServiceUpgradeStrategy `json:"toServiceStrategy,omitempty" yaml:"to_service_strategy,omitempty"`
 }
 
 type ServiceUpgradeCollection struct {
@@ -66,6 +56,11 @@ func (c *ServiceUpgradeClient) List(opts *ListOpts) (*ServiceUpgradeCollection, 
 func (c *ServiceUpgradeClient) ById(id string) (*ServiceUpgrade, error) {
 	resp := &ServiceUpgrade{}
 	err := c.rancherClient.doById(SERVICE_UPGRADE_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_service_upgrade_strategy.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_service_upgrade_strategy.go
@@ -1,0 +1,69 @@
+package client
+
+const (
+	SERVICE_UPGRADE_STRATEGY_TYPE = "serviceUpgradeStrategy"
+)
+
+type ServiceUpgradeStrategy struct {
+	Resource
+
+	BatchSize int64 `json:"batchSize,omitempty" yaml:"batch_size,omitempty"`
+
+	IntervalMillis int64 `json:"intervalMillis,omitempty" yaml:"interval_millis,omitempty"`
+}
+
+type ServiceUpgradeStrategyCollection struct {
+	Collection
+	Data []ServiceUpgradeStrategy `json:"data,omitempty"`
+}
+
+type ServiceUpgradeStrategyClient struct {
+	rancherClient *RancherClient
+}
+
+type ServiceUpgradeStrategyOperations interface {
+	List(opts *ListOpts) (*ServiceUpgradeStrategyCollection, error)
+	Create(opts *ServiceUpgradeStrategy) (*ServiceUpgradeStrategy, error)
+	Update(existing *ServiceUpgradeStrategy, updates interface{}) (*ServiceUpgradeStrategy, error)
+	ById(id string) (*ServiceUpgradeStrategy, error)
+	Delete(container *ServiceUpgradeStrategy) error
+}
+
+func newServiceUpgradeStrategyClient(rancherClient *RancherClient) *ServiceUpgradeStrategyClient {
+	return &ServiceUpgradeStrategyClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ServiceUpgradeStrategyClient) Create(container *ServiceUpgradeStrategy) (*ServiceUpgradeStrategy, error) {
+	resp := &ServiceUpgradeStrategy{}
+	err := c.rancherClient.doCreate(SERVICE_UPGRADE_STRATEGY_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ServiceUpgradeStrategyClient) Update(existing *ServiceUpgradeStrategy, updates interface{}) (*ServiceUpgradeStrategy, error) {
+	resp := &ServiceUpgradeStrategy{}
+	err := c.rancherClient.doUpdate(SERVICE_UPGRADE_STRATEGY_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ServiceUpgradeStrategyClient) List(opts *ListOpts) (*ServiceUpgradeStrategyCollection, error) {
+	resp := &ServiceUpgradeStrategyCollection{}
+	err := c.rancherClient.doList(SERVICE_UPGRADE_STRATEGY_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ServiceUpgradeStrategyClient) ById(id string) (*ServiceUpgradeStrategy, error) {
+	resp := &ServiceUpgradeStrategy{}
+	err := c.rancherClient.doById(SERVICE_UPGRADE_STRATEGY_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ServiceUpgradeStrategyClient) Delete(container *ServiceUpgradeStrategy) error {
+	return c.rancherClient.doResourceDelete(SERVICE_UPGRADE_STRATEGY_TYPE, &container.Resource)
+}

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_set_labels_input.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_set_labels_input.go
@@ -54,6 +54,11 @@ func (c *SetLabelsInputClient) List(opts *ListOpts) (*SetLabelsInputCollection, 
 func (c *SetLabelsInputClient) ById(id string) (*SetLabelsInput, error) {
 	resp := &SetLabelsInput{}
 	err := c.rancherClient.doById(SET_LABELS_INPUT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_set_load_balancer_hosts_input.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_set_load_balancer_hosts_input.go
@@ -54,6 +54,11 @@ func (c *SetLoadBalancerHostsInputClient) List(opts *ListOpts) (*SetLoadBalancer
 func (c *SetLoadBalancerHostsInputClient) ById(id string) (*SetLoadBalancerHostsInput, error) {
 	resp := &SetLoadBalancerHostsInput{}
 	err := c.rancherClient.doById(SET_LOAD_BALANCER_HOSTS_INPUT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_set_load_balancer_listeners_input.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_set_load_balancer_listeners_input.go
@@ -54,6 +54,11 @@ func (c *SetLoadBalancerListenersInputClient) List(opts *ListOpts) (*SetLoadBala
 func (c *SetLoadBalancerListenersInputClient) ById(id string) (*SetLoadBalancerListenersInput, error) {
 	resp := &SetLoadBalancerListenersInput{}
 	err := c.rancherClient.doById(SET_LOAD_BALANCER_LISTENERS_INPUT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_set_load_balancer_service_links_input.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_set_load_balancer_service_links_input.go
@@ -54,6 +54,11 @@ func (c *SetLoadBalancerServiceLinksInputClient) List(opts *ListOpts) (*SetLoadB
 func (c *SetLoadBalancerServiceLinksInputClient) ById(id string) (*SetLoadBalancerServiceLinksInput, error) {
 	resp := &SetLoadBalancerServiceLinksInput{}
 	err := c.rancherClient.doById(SET_LOAD_BALANCER_SERVICE_LINKS_INPUT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_set_load_balancer_targets_input.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_set_load_balancer_targets_input.go
@@ -54,6 +54,11 @@ func (c *SetLoadBalancerTargetsInputClient) List(opts *ListOpts) (*SetLoadBalanc
 func (c *SetLoadBalancerTargetsInputClient) ById(id string) (*SetLoadBalancerTargetsInput, error) {
 	resp := &SetLoadBalancerTargetsInput{}
 	err := c.rancherClient.doById(SET_LOAD_BALANCER_TARGETS_INPUT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_set_project_members_input.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_set_project_members_input.go
@@ -54,6 +54,11 @@ func (c *SetProjectMembersInputClient) List(opts *ListOpts) (*SetProjectMembersI
 func (c *SetProjectMembersInputClient) ById(id string) (*SetProjectMembersInput, error) {
 	resp := &SetProjectMembersInput{}
 	err := c.rancherClient.doById(SET_PROJECT_MEMBERS_INPUT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_set_service_links_input.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_set_service_links_input.go
@@ -54,6 +54,11 @@ func (c *SetServiceLinksInputClient) List(opts *ListOpts) (*SetServiceLinksInput
 func (c *SetServiceLinksInputClient) ById(id string) (*SetServiceLinksInput, error) {
 	resp := &SetServiceLinksInput{}
 	err := c.rancherClient.doById(SET_SERVICE_LINKS_INPUT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_setting.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_setting.go
@@ -56,6 +56,11 @@ func (c *SettingClient) List(opts *ListOpts) (*SettingCollection, error) {
 func (c *SettingClient) ById(id string) (*Setting, error) {
 	resp := &Setting{}
 	err := c.rancherClient.doById(SETTING_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_snapshot.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_snapshot.go
@@ -88,6 +88,11 @@ func (c *SnapshotClient) List(opts *ListOpts) (*SnapshotCollection, error) {
 func (c *SnapshotClient) ById(id string) (*Snapshot, error) {
 	resp := &Snapshot{}
 	err := c.rancherClient.doById(SNAPSHOT_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_softlayer_config.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_softlayer_config.go
@@ -82,6 +82,11 @@ func (c *SoftlayerConfigClient) List(opts *ListOpts) (*SoftlayerConfigCollection
 func (c *SoftlayerConfigClient) ById(id string) (*SoftlayerConfig, error) {
 	resp := &SoftlayerConfig{}
 	err := c.rancherClient.doById(SOFTLAYER_CONFIG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_state_transition.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_state_transition.go
@@ -52,6 +52,11 @@ func (c *StateTransitionClient) List(opts *ListOpts) (*StateTransitionCollection
 func (c *StateTransitionClient) ById(id string) (*StateTransition, error) {
 	resp := &StateTransition{}
 	err := c.rancherClient.doById(STATE_TRANSITION_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_stats_access.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_stats_access.go
@@ -56,6 +56,11 @@ func (c *StatsAccessClient) List(opts *ListOpts) (*StatsAccessCollection, error)
 func (c *StatsAccessClient) ById(id string) (*StatsAccess, error) {
 	resp := &StatsAccess{}
 	err := c.rancherClient.doById(STATS_ACCESS_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_storage_pool.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_storage_pool.go
@@ -15,6 +15,8 @@ type StoragePool struct {
 
 	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 
+	DriverName string `json:"driverName,omitempty" yaml:"driver_name,omitempty"`
+
 	ExternalId string `json:"externalId,omitempty" yaml:"external_id,omitempty"`
 
 	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
@@ -94,6 +96,11 @@ func (c *StoragePoolClient) List(opts *ListOpts) (*StoragePoolCollection, error)
 func (c *StoragePoolClient) ById(id string) (*StoragePool, error) {
 	resp := &StoragePool{}
 	err := c.rancherClient.doById(STORAGE_POOL_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_subscribe.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_subscribe.go
@@ -56,6 +56,11 @@ func (c *SubscribeClient) List(opts *ListOpts) (*SubscribeCollection, error) {
 func (c *SubscribeClient) ById(id string) (*Subscribe, error) {
 	resp := &Subscribe{}
 	err := c.rancherClient.doById(SUBSCRIBE_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_task.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_task.go
@@ -56,6 +56,11 @@ func (c *TaskClient) List(opts *ListOpts) (*TaskCollection, error) {
 func (c *TaskClient) ById(id string) (*Task, error) {
 	resp := &Task{}
 	err := c.rancherClient.doById(TASK_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_task_instance.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_task_instance.go
@@ -64,6 +64,11 @@ func (c *TaskInstanceClient) List(opts *ListOpts) (*TaskInstanceCollection, erro
 func (c *TaskInstanceClient) ById(id string) (*TaskInstance, error) {
 	resp := &TaskInstance{}
 	err := c.rancherClient.doById(TASK_INSTANCE_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_to_service_upgrade_strategy.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_to_service_upgrade_strategy.go
@@ -1,0 +1,75 @@
+package client
+
+const (
+	TO_SERVICE_UPGRADE_STRATEGY_TYPE = "toServiceUpgradeStrategy"
+)
+
+type ToServiceUpgradeStrategy struct {
+	Resource
+
+	BatchSize int64 `json:"batchSize,omitempty" yaml:"batch_size,omitempty"`
+
+	FinalScale int64 `json:"finalScale,omitempty" yaml:"final_scale,omitempty"`
+
+	IntervalMillis int64 `json:"intervalMillis,omitempty" yaml:"interval_millis,omitempty"`
+
+	ToServiceId string `json:"toServiceId,omitempty" yaml:"to_service_id,omitempty"`
+
+	UpdateLinks bool `json:"updateLinks,omitempty" yaml:"update_links,omitempty"`
+}
+
+type ToServiceUpgradeStrategyCollection struct {
+	Collection
+	Data []ToServiceUpgradeStrategy `json:"data,omitempty"`
+}
+
+type ToServiceUpgradeStrategyClient struct {
+	rancherClient *RancherClient
+}
+
+type ToServiceUpgradeStrategyOperations interface {
+	List(opts *ListOpts) (*ToServiceUpgradeStrategyCollection, error)
+	Create(opts *ToServiceUpgradeStrategy) (*ToServiceUpgradeStrategy, error)
+	Update(existing *ToServiceUpgradeStrategy, updates interface{}) (*ToServiceUpgradeStrategy, error)
+	ById(id string) (*ToServiceUpgradeStrategy, error)
+	Delete(container *ToServiceUpgradeStrategy) error
+}
+
+func newToServiceUpgradeStrategyClient(rancherClient *RancherClient) *ToServiceUpgradeStrategyClient {
+	return &ToServiceUpgradeStrategyClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *ToServiceUpgradeStrategyClient) Create(container *ToServiceUpgradeStrategy) (*ToServiceUpgradeStrategy, error) {
+	resp := &ToServiceUpgradeStrategy{}
+	err := c.rancherClient.doCreate(TO_SERVICE_UPGRADE_STRATEGY_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *ToServiceUpgradeStrategyClient) Update(existing *ToServiceUpgradeStrategy, updates interface{}) (*ToServiceUpgradeStrategy, error) {
+	resp := &ToServiceUpgradeStrategy{}
+	err := c.rancherClient.doUpdate(TO_SERVICE_UPGRADE_STRATEGY_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *ToServiceUpgradeStrategyClient) List(opts *ListOpts) (*ToServiceUpgradeStrategyCollection, error) {
+	resp := &ToServiceUpgradeStrategyCollection{}
+	err := c.rancherClient.doList(TO_SERVICE_UPGRADE_STRATEGY_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *ToServiceUpgradeStrategyClient) ById(id string) (*ToServiceUpgradeStrategy, error) {
+	resp := &ToServiceUpgradeStrategy{}
+	err := c.rancherClient.doById(TO_SERVICE_UPGRADE_STRATEGY_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *ToServiceUpgradeStrategyClient) Delete(container *ToServiceUpgradeStrategy) error {
+	return c.rancherClient.doResourceDelete(TO_SERVICE_UPGRADE_STRATEGY_TYPE, &container.Resource)
+}

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_type_documentation.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_type_documentation.go
@@ -56,6 +56,11 @@ func (c *TypeDocumentationClient) List(opts *ListOpts) (*TypeDocumentationCollec
 func (c *TypeDocumentationClient) ById(id string) (*TypeDocumentation, error) {
 	resp := &TypeDocumentation{}
 	err := c.rancherClient.doById(TYPE_DOCUMENTATION_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_ubiquity_config.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_ubiquity_config.go
@@ -1,0 +1,77 @@
+package client
+
+const (
+	UBIQUITY_CONFIG_TYPE = "ubiquityConfig"
+)
+
+type UbiquityConfig struct {
+	Resource
+
+	ApiToken string `json:"apiToken,omitempty" yaml:"api_token,omitempty"`
+
+	ApiUsername string `json:"apiUsername,omitempty" yaml:"api_username,omitempty"`
+
+	ClientId string `json:"clientId,omitempty" yaml:"client_id,omitempty"`
+
+	FlavorId string `json:"flavorId,omitempty" yaml:"flavor_id,omitempty"`
+
+	ImageId string `json:"imageId,omitempty" yaml:"image_id,omitempty"`
+
+	ZoneId string `json:"zoneId,omitempty" yaml:"zone_id,omitempty"`
+}
+
+type UbiquityConfigCollection struct {
+	Collection
+	Data []UbiquityConfig `json:"data,omitempty"`
+}
+
+type UbiquityConfigClient struct {
+	rancherClient *RancherClient
+}
+
+type UbiquityConfigOperations interface {
+	List(opts *ListOpts) (*UbiquityConfigCollection, error)
+	Create(opts *UbiquityConfig) (*UbiquityConfig, error)
+	Update(existing *UbiquityConfig, updates interface{}) (*UbiquityConfig, error)
+	ById(id string) (*UbiquityConfig, error)
+	Delete(container *UbiquityConfig) error
+}
+
+func newUbiquityConfigClient(rancherClient *RancherClient) *UbiquityConfigClient {
+	return &UbiquityConfigClient{
+		rancherClient: rancherClient,
+	}
+}
+
+func (c *UbiquityConfigClient) Create(container *UbiquityConfig) (*UbiquityConfig, error) {
+	resp := &UbiquityConfig{}
+	err := c.rancherClient.doCreate(UBIQUITY_CONFIG_TYPE, container, resp)
+	return resp, err
+}
+
+func (c *UbiquityConfigClient) Update(existing *UbiquityConfig, updates interface{}) (*UbiquityConfig, error) {
+	resp := &UbiquityConfig{}
+	err := c.rancherClient.doUpdate(UBIQUITY_CONFIG_TYPE, &existing.Resource, updates, resp)
+	return resp, err
+}
+
+func (c *UbiquityConfigClient) List(opts *ListOpts) (*UbiquityConfigCollection, error) {
+	resp := &UbiquityConfigCollection{}
+	err := c.rancherClient.doList(UBIQUITY_CONFIG_TYPE, opts, resp)
+	return resp, err
+}
+
+func (c *UbiquityConfigClient) ById(id string) (*UbiquityConfig, error) {
+	resp := &UbiquityConfig{}
+	err := c.rancherClient.doById(UBIQUITY_CONFIG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
+	return resp, err
+}
+
+func (c *UbiquityConfigClient) Delete(container *UbiquityConfig) error {
+	return c.rancherClient.doResourceDelete(UBIQUITY_CONFIG_TYPE, &container.Resource)
+}

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_user_preference.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_user_preference.go
@@ -7,33 +7,33 @@ const (
 type UserPreference struct {
 	Resource
 
-	AccountId string `json:"accountId,omitempty"`
+	AccountId string `json:"accountId,omitempty" yaml:"account_id,omitempty"`
 
-	Created string `json:"created,omitempty"`
+	Created string `json:"created,omitempty" yaml:"created,omitempty"`
 
-	Data map[string]interface{} `json:"data,omitempty"`
+	Data map[string]interface{} `json:"data,omitempty" yaml:"data,omitempty"`
 
-	Description string `json:"description,omitempty"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
 
-	Kind string `json:"kind,omitempty"`
+	Kind string `json:"kind,omitempty" yaml:"kind,omitempty"`
 
-	Name string `json:"name,omitempty"`
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
 
-	RemoveTime string `json:"removeTime,omitempty"`
+	RemoveTime string `json:"removeTime,omitempty" yaml:"remove_time,omitempty"`
 
-	Removed string `json:"removed,omitempty"`
+	Removed string `json:"removed,omitempty" yaml:"removed,omitempty"`
 
-	State string `json:"state,omitempty"`
+	State string `json:"state,omitempty" yaml:"state,omitempty"`
 
-	Transitioning string `json:"transitioning,omitempty"`
+	Transitioning string `json:"transitioning,omitempty" yaml:"transitioning,omitempty"`
 
-	TransitioningMessage string `json:"transitioningMessage,omitempty"`
+	TransitioningMessage string `json:"transitioningMessage,omitempty" yaml:"transitioning_message,omitempty"`
 
-	TransitioningProgress int `json:"transitioningProgress,omitempty"`
+	TransitioningProgress int64 `json:"transitioningProgress,omitempty" yaml:"transitioning_progress,omitempty"`
 
-	Uuid string `json:"uuid,omitempty"`
+	Uuid string `json:"uuid,omitempty" yaml:"uuid,omitempty"`
 
-	Value string `json:"value,omitempty"`
+	Value string `json:"value,omitempty" yaml:"value,omitempty"`
 }
 
 type UserPreferenceCollection struct {

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_virtualbox_config.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_virtualbox_config.go
@@ -66,6 +66,11 @@ func (c *VirtualboxConfigClient) List(opts *ListOpts) (*VirtualboxConfigCollecti
 func (c *VirtualboxConfigClient) ById(id string) (*VirtualboxConfig, error) {
 	resp := &VirtualboxConfig{}
 	err := c.rancherClient.doById(VIRTUALBOX_CONFIG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_vmwarevcloudair_config.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_vmwarevcloudair_config.go
@@ -80,6 +80,11 @@ func (c *VmwarevcloudairConfigClient) List(opts *ListOpts) (*VmwarevcloudairConf
 func (c *VmwarevcloudairConfigClient) ById(id string) (*VmwarevcloudairConfig, error) {
 	resp := &VmwarevcloudairConfig{}
 	err := c.rancherClient.doById(VMWAREVCLOUDAIR_CONFIG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_vmwarevsphere_config.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_vmwarevsphere_config.go
@@ -76,6 +76,11 @@ func (c *VmwarevsphereConfigClient) List(opts *ListOpts) (*VmwarevsphereConfigCo
 func (c *VmwarevsphereConfigClient) ById(id string) (*VmwarevsphereConfig, error) {
 	resp := &VmwarevsphereConfig{}
 	err := c.rancherClient.doById(VMWAREVSPHERE_CONFIG_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_volume.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/generated_volume.go
@@ -108,6 +108,11 @@ func (c *VolumeClient) List(opts *ListOpts) (*VolumeCollection, error) {
 func (c *VolumeClient) ById(id string) (*Volume, error) {
 	resp := &Volume{}
 	err := c.rancherClient.doById(VOLUME_TYPE, id, resp)
+	if apiError, ok := err.(*ApiError); ok {
+		if apiError.StatusCode == 404 {
+			return nil, nil
+		}
+	}
 	return resp, err
 }
 

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/schemas.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/schemas.go
@@ -1,0 +1,129 @@
+package client
+
+import (
+	"reflect"
+	"strings"
+)
+
+type Schemas struct {
+	Collection
+	Data          []Schema `json:"data,omitempty"`
+	schemasByName map[string]*Schema
+}
+
+func (s *Schema) CheckField(name string) (Field, bool) {
+	for fieldName := range s.ResourceFields {
+		if fieldName == name {
+			v, ok := s.ResourceFields[fieldName]
+			return v, ok
+		}
+	}
+	return Field{}, false
+}
+
+func (s *Schema) Field(name string) Field {
+	f, _ := s.CheckField(name)
+	return f
+}
+
+func (s *Schemas) CheckSchema(name string) (Schema, bool) {
+	for i := range s.Data {
+		if s.Data[i].Id == name {
+			return s.Data[i], true
+		}
+	}
+	return Schema{}, false
+}
+
+func (s *Schemas) Schema(name string) Schema {
+	r, _ := s.CheckSchema(name)
+	return r
+}
+
+func typeToFields(t reflect.Type) map[string]Field {
+	result := map[string]Field{}
+
+	for i := 0; i < t.NumField(); i++ {
+		schemaField := Field{}
+
+		typeField := t.Field(i)
+		if typeField.Anonymous && typeField.Type.Kind() == reflect.Struct {
+			parentFields := typeToFields(typeField.Type)
+			for k, v := range result {
+				parentFields[k] = v
+			}
+			result = parentFields
+			continue
+		} else if typeField.Anonymous {
+			continue
+		}
+
+		fieldString := strings.ToLower(typeField.Type.Kind().String())
+
+		switch {
+		case strings.HasPrefix(fieldString, "int") || strings.HasPrefix(fieldString, "uint"):
+			schemaField.Type = "int"
+		case fieldString == "bool":
+			schemaField.Type = fieldString
+		case fieldString == "float32" || fieldString == "float64":
+			schemaField.Type = "float"
+		case fieldString == "string":
+			schemaField.Type = "string"
+		case fieldString == "map":
+			// HACK
+			schemaField.Type = "map[string]"
+		case fieldString == "slice":
+			// HACK
+			schemaField.Type = "array[string]"
+		}
+
+		name := strings.Split(typeField.Tag.Get("json"), ",")[0]
+		if name == "" && len(typeField.Name) > 1 {
+			name = strings.ToLower(typeField.Name[0:1]) + typeField.Name[1:]
+		} else if name == "" {
+			name = typeField.Name
+		}
+
+		if schemaField.Type != "" {
+			result[name] = schemaField
+		}
+	}
+
+	return result
+}
+
+func (s *Schemas) AddType(schemaName string, obj interface{}) *Schema {
+	t := reflect.TypeOf(obj)
+	schema := Schema{
+		Resource: Resource{
+			Id:    schemaName,
+			Type:  "schema",
+			Links: map[string]string{},
+		},
+		PluralName:        guessPluralName(schemaName),
+		ResourceFields:    typeToFields(t),
+		CollectionMethods: []string{"GET"},
+		ResourceMethods:   []string{"GET"},
+	}
+
+	if s.Data == nil {
+		s.Data = []Schema{}
+	}
+
+	s.Data = append(s.Data, schema)
+
+	return &s.Data[len(s.Data)-1]
+}
+
+func guessPluralName(name string) string {
+	if name == "" {
+		return ""
+	}
+
+	if strings.HasSuffix(name, "s") ||
+		strings.HasSuffix(name, "ch") ||
+		strings.HasSuffix(name, "x") {
+		return name + "es"
+	}
+	return name + "s"
+}

--- a/Godeps/_workspace/src/github.com/rancher/go-rancher/client/types.go
+++ b/Godeps/_workspace/src/github.com/rancher/go-rancher/client/types.go
@@ -12,6 +12,11 @@ type Collection struct {
 	Filters      map[string][]Condition `json:"filters,omitempty"`
 }
 
+type GenericCollection struct {
+	Collection
+	Data []interface{} `json:"data,omitempty"`
+}
+
 type Sort struct {
 	Name    string `json:"name,omitempty"`
 	Order   string `json:"order,omitempty"`
@@ -36,13 +41,8 @@ type Pagination struct {
 type Resource struct {
 	Id      string            `json:"id,omitempty"`
 	Type    string            `json:"type,omitempty"`
-	Links   map[string]string `json:"links,omitempty"`
-	Actions map[string]string `json:"actions,omitempty"`
-}
-
-type Schemas struct {
-	Collection
-	Data []Schema `json:"data,omitempty"`
+	Links   map[string]string `json:"links"`
+	Actions map[string]string `json:"actions"`
 }
 
 type Schema struct {

--- a/main.go
+++ b/main.go
@@ -59,16 +59,7 @@ func main() {
 		},
 		cli.StringFlag{
 			Name:  "storagepool-driver",
-			Usage: "set the storage pool driver",
-			Value: "convoy",
-		},
-		cli.StringFlag{
-			Name:  "storagepool-name",
-			Usage: "set the storage pool name",
-		},
-		cli.StringFlag{
-			Name:  "storagepool-uuid",
-			Usage: "set the storage pool uuid",
+			Usage: "set the storage pool driver.",
 		},
 	}
 

--- a/packaging/convoy-gluster/docker-compose.yml
+++ b/packaging/convoy-gluster/docker-compose.yml
@@ -1,7 +1,6 @@
 convoy-gluster-volume:
-  restart: always
   labels:
-          io.rancher.scheduler.affinity:container_label_ne: io.rancher.stack_service.name=convoy-gluster-volume
+    io.rancher.scheduler.affinity:container_label_ne: io.rancher.stack_service.name=convoy-gluster-volume
     io.rancher.container.pull_image: always
     io.rancher.container.create_agent: 'true'
     io.rancher.scheduler.global: 'true'

--- a/packaging/convoy-gluster/storagepool-agent/launch
+++ b/packaging/convoy-gluster/storagepool-agent/launch
@@ -6,7 +6,6 @@ sleep 10
 
 HEALTHCHECK_TYPE="metadata"
 
-STORAGEPOOL_DRIVER="convoy-gluster"
 STACK_NAME=$(curl -s http://rancher-metadata/latest/self/stack/name)
 
 exec convoy-agent \
@@ -14,8 +13,6 @@ exec convoy-agent \
 	--url $CATTLE_URL \
 	--access-key $CATTLE_ACCESS_KEY \
 	--secret-key $CATTLE_SECRET_KEY \
-	--storagepool-uuid $STACK_NAME \
 	--storagepool-driver $STACK_NAME \
-	--storagepool-name $STACK_NAME \
 	storagepool \
 	--storagepool-healthcheck-type $HEALTHCHECK_TYPE

--- a/packaging/convoy-gluster/volume-agent/convoy-gluster-launcher
+++ b/packaging/convoy-gluster/volume-agent/convoy-gluster-launcher
@@ -6,6 +6,8 @@
 
 set -e
 
+sleep 30
+
 get_metadata() {
     echo $(curl -s http://rancher-metadata/latest/services/convoy-gluster/metadata/$1)
 }
@@ -16,8 +18,6 @@ SERVICE_NAME=$(get_metadata gluster_service)
 VOLUME_POOL=$(get_metadata volume_pool)
 
 CONVOY_SOCK=/var/run/convoy/$STACK_NAME.sock
-
-sleep 30
 
 HOST_UUID=$(curl -s http://rancher-metadata/latest/self/host/uuid)
 
@@ -43,4 +43,5 @@ exec convoy-agent \
     --secret-key $CATTLE_SECRET_KEY \
     --storagepool-driver $STACK_NAME \
     volume \
+    --socket $CONVOY_SOCK \
     --host-uuid $HOST_UUID

--- a/packaging/convoy-gluster/volume-agent/convoy-gluster-launcher
+++ b/packaging/convoy-gluster/volume-agent/convoy-gluster-launcher
@@ -6,44 +6,41 @@
 
 set -e
 
-CONVOY_SOCK=/var/run/convoy/convoy.sock
-
-STORAGEPOOL_DRIVER="convoy"
-
-sleep 30
-
 get_metadata() {
-	echo $(curl -s http://rancher-metadata/latest/services/convoy-gluster/metadata/$1)
+    echo $(curl -s http://rancher-metadata/latest/services/convoy-gluster/metadata/$1)
 }
 
-
-STACK_NAME=$(get_metadata gluster_stack)
+GLUSTER_STACK_NAME=$(get_metadata gluster_stack)
+STACK_NAME=$(curl -s http://rancher-metadata/latest/self/stack/name)
 SERVICE_NAME=$(get_metadata gluster_service)
 VOLUME_POOL=$(get_metadata volume_pool)
+
+CONVOY_SOCK=/var/run/convoy/$STACK_NAME.sock
+
+sleep 30
 
 HOST_UUID=$(curl -s http://rancher-metadata/latest/self/host/uuid)
 
 nsenter --mount=/host/proc/1/ns/mnt /bin/bash -c "\
-	add-apt-repository ppa:gluster/glusterfs-3.7 && apt-get update && \
-	apt-get install -y --no-install-recommends \
-		openssh-server \
-		vim \
-		wget \
-		software-properties-common \
-		glusterfs-client"
+    add-apt-repository ppa:gluster/glusterfs-3.7 && apt-get update && \
+    apt-get install -y --no-install-recommends \
+        openssh-server \
+        vim \
+        wget \
+        software-properties-common \
+        glusterfs-client"
 
 convoy --socket $CONVOY_SOCK daemon --mnt-ns /host/proc/1/ns/mnt \
-	--drivers glusterfs \
-       	--driver-opts glusterfs.rancherstack=$STACK_NAME \
-	--driver-opts glusterfs.rancherservice=$SERVICE_NAME \
-	--driver-opts glusterfs.defaultvolumepool=$VOLUME_POOL &
-echo "unix://$CONVOY_SOCK" > /etc/docker/plugins/convoy.spec
+    --drivers glusterfs \
+    --driver-opts glusterfs.rancherstack=$GLUSTER_STACK_NAME \
+    --driver-opts glusterfs.rancherservice=$SERVICE_NAME \
+    --driver-opts glusterfs.defaultvolumepool=$VOLUME_POOL &
+echo "unix://$CONVOY_SOCK" > /etc/docker/plugins/$STACK_NAME.spec
 
 exec convoy-agent \
-	--url $CATTLE_URL \
-	--access-key $CATTLE_ACCESS_KEY \
-	--secret-key $CATTLE_SECRET_KEY \
-	--storagepool-driver $STORAGEPOOL_DRIVER \
-	--storagepool-uuid $STACK_NAME \
-	volume \
-	--host-uuid $HOST_UUID
+    --url $CATTLE_URL \
+    --access-key $CATTLE_ACCESS_KEY \
+    --secret-key $CATTLE_SECRET_KEY \
+    --storagepool-driver $STACK_NAME \
+    volume \
+    --host-uuid $HOST_UUID

--- a/packaging/convoy-nfs/storagepool-agent/launch
+++ b/packaging/convoy-nfs/storagepool-agent/launch
@@ -6,7 +6,6 @@ sleep 10
 
 HEALTHCHECK_TYPE="metadata"
 
-STORAGEPOOL_DRIVER="convoy-gluster"
 STACK_NAME=$(curl -s http://rancher-metadata/latest/self/stack/name)
 
 exec convoy-agent \
@@ -14,8 +13,6 @@ exec convoy-agent \
 	--url $CATTLE_URL \
 	--access-key $CATTLE_ACCESS_KEY \
 	--secret-key $CATTLE_SECRET_KEY \
-	--storagepool-uuid $STACK_NAME \
 	--storagepool-driver $STACK_NAME \
-	--storagepool-name $STACK_NAME \
 	storagepool \
 	--storagepool-healthcheck-type $HEALTHCHECK_TYPE

--- a/storagepool/agent.go
+++ b/storagepool/agent.go
@@ -15,17 +15,17 @@ var rootUuidFileName = "UUID"
 type StoragepoolAgent struct {
 	healthCheckInterval int
 	storagepoolRootDir  string
-	storagepoolUuid     string
+	driver              string
 	healthCheckBaseDir  string
 	healthCheckType     string
 	cattleClient        cattle.CattleInterface
 }
 
-func NewStoragepoolAgent(healthCheckInterval int, storagepoolRootDir, storagepoolUuid, healthCheckBaseDir, healthCheckType string, cattleClient cattle.CattleInterface) *StoragepoolAgent {
+func NewStoragepoolAgent(healthCheckInterval int, storagepoolRootDir, driver, healthCheckBaseDir, healthCheckType string, cattleClient cattle.CattleInterface) *StoragepoolAgent {
 	return &StoragepoolAgent{
 		healthCheckInterval: healthCheckInterval,
 		storagepoolRootDir:  storagepoolRootDir,
-		storagepoolUuid:     storagepoolUuid,
+		driver:              driver,
 		healthCheckBaseDir:  healthCheckBaseDir,
 		healthCheckType:     healthCheckType,
 		cattleClient:        cattleClient,
@@ -33,8 +33,9 @@ func NewStoragepoolAgent(healthCheckInterval int, storagepoolRootDir, storagepoo
 }
 
 func (s *StoragepoolAgent) Run(metadataUrl string) error {
+	// TODO Can we delete his non metadata healthcheck code?
 	if _, err := os.Stat(filepath.Join(s.storagepoolRootDir, rootUuidFileName)); os.IsNotExist(err) && s.healthCheckType != "metadata" {
-		err := ioutil.WriteFile(filepath.Join(s.storagepoolRootDir, rootUuidFileName), []byte(s.storagepoolUuid), 0644)
+		err := ioutil.WriteFile(filepath.Join(s.storagepoolRootDir, rootUuidFileName), []byte(s.driver), 0644)
 		if err != nil {
 			return err
 		}
@@ -96,7 +97,7 @@ func (s *StoragepoolAgent) Run(metadataUrl string) error {
 			for k := range toSend {
 				toSendList = append(toSendList, k)
 			}
-			err := s.cattleClient.SyncStoragePool(s.storagepoolUuid, toSendList)
+			err := s.cattleClient.SyncStoragePool(s.driver, toSendList)
 			if err != nil {
 				log.Errorf("Error syncing storage pool events [%v]", err)
 				continue

--- a/storagepool/storagepool.go
+++ b/storagepool/storagepool.go
@@ -31,12 +31,6 @@ func storagepoolAgent(c *cli.Context) {
 	healthCheckInterval := c.GlobalInt("healthcheck-interval")
 	healthCheckBaseDir := c.GlobalString("healthcheck-basedir")
 	healthCheckType := c.String("storagepool-healthcheck-type")
-	storagepoolUUID := c.GlobalString("storagepool-uuid")
-	if storagepoolUUID == "" {
-		log.Fatalf("Required field storagepool uuid [\"storagepool-uuid\"] is not set")
-	}
-
-	storagepoolRootDir := c.GlobalString("storagepool-rootdir")
 
 	cattleUrl := c.GlobalString("url")
 	cattleAccessKey := c.GlobalString("access-key")
@@ -45,18 +39,18 @@ func storagepoolAgent(c *cli.Context) {
 		log.SetLevel(log.DebugLevel)
 	}
 
-	storagepoolDriver := c.GlobalString("storagepool-driver")
-	storagepoolName := c.GlobalString("storagepool-name")
-	if storagepoolName == "" {
-		log.Fatal("required field storagepool-name has not been set")
+	storagepoolRootDir := c.GlobalString("storagepool-rootdir")
+	driver := c.GlobalString("storagepool-driver")
+	if driver == "" {
+		log.Fatal("required field storagepool-driver has not been set")
 	}
 
-	cattleClient, err := cattle.NewCattleClient(cattleUrl, cattleAccessKey, cattleSecretKey, storagepoolDriver, storagepoolName)
+	cattleClient, err := cattle.NewCattleClient(cattleUrl, cattleAccessKey, cattleSecretKey)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	storagepoolAgent := NewStoragepoolAgent(healthCheckInterval, storagepoolRootDir, storagepoolUUID, healthCheckBaseDir, healthCheckType, cattleClient)
+	storagepoolAgent := NewStoragepoolAgent(healthCheckInterval, storagepoolRootDir, driver, healthCheckBaseDir, healthCheckType, cattleClient)
 
 	metadataUrl := c.String("storagepool-metadata-url")
 

--- a/tests/test_client.go
+++ b/tests/test_client.go
@@ -11,18 +11,18 @@ type testCattleClient struct {
 	hosts      [][]string
 }
 
-func (t *testCattleClient) CreateVolume(storagepoolUuid string, vol api.VolumeResponse) error {
+func (t *testCattleClient) CreateVolume(driver string, vol api.VolumeResponse) error {
 	t.lastEvents = append(t.lastEvents, fmt.Sprintf("CREATED_%s", vol.UUID))
 	return nil
 }
 
-func (t *testCattleClient) DeleteVolume(storagepoolUuid string, vol api.VolumeResponse) error {
+func (t *testCattleClient) DeleteVolume(driver string, vol api.VolumeResponse) error {
 	t.lastEvents = append(t.lastEvents, fmt.Sprintf("DELETED_%s", vol.UUID))
 	return nil
 }
 
-func (t *testCattleClient) SyncStoragePool(storagepoolUuid string, hostUuids []string) error {
-	t.lastEvents = append(t.lastEvents, fmt.Sprintf("SYNC_%s", storagepoolUuid))
+func (t *testCattleClient) SyncStoragePool(driver string, hostUuids []string) error {
+	t.lastEvents = append(t.lastEvents, fmt.Sprintf("SYNC_%s", driver))
 	t.hosts = append(t.hosts, hostUuids)
 	return nil
 }

--- a/volume/agent.go
+++ b/volume/agent.go
@@ -12,18 +12,18 @@ type VolumeAgent struct {
 	socketFile          string
 	healthCheckInterval int
 	cattleClient        cattle.CattleInterface
-	storagepoolUuid     string
 	hostUuid            string
+	driver              string
 }
 
-func NewVolumeAgent(healthCheckBaseDir, socketFile, hostUuid string, healthCheckInterval int, cattleClient cattle.CattleInterface, storagepoolUuid string) *VolumeAgent {
+func NewVolumeAgent(healthCheckBaseDir, socketFile, hostUuid string, healthCheckInterval int, cattleClient cattle.CattleInterface, driver string) *VolumeAgent {
 	return &VolumeAgent{
 		healthCheckBaseDir:  healthCheckBaseDir,
 		socketFile:          socketFile,
 		healthCheckInterval: healthCheckInterval,
 		cattleClient:        cattleClient,
-		storagepoolUuid:     storagepoolUuid,
 		hostUuid:            hostUuid,
+		driver:              driver,
 	}
 }
 
@@ -54,7 +54,7 @@ func (v *VolumeAgent) Run(controlChan chan bool) error {
 		createdVols := findCreatedVolumes(currVols, vols)
 
 		for _, vol := range deletedVols {
-			err := v.cattleClient.DeleteVolume(v.storagepoolUuid, vol)
+			err := v.cattleClient.DeleteVolume(v.driver, vol)
 			if err != nil {
 				log.Errorf("Error sending delete event for volume ID=[%s] err=[%v]", vol.UUID, err)
 				currVols[vol.UUID] = vols[vol.UUID]
@@ -62,7 +62,7 @@ func (v *VolumeAgent) Run(controlChan chan bool) error {
 		}
 
 		for _, vol := range createdVols {
-			err := v.cattleClient.CreateVolume(v.storagepoolUuid, vol)
+			err := v.cattleClient.CreateVolume(v.driver, vol)
 			if err != nil {
 				log.Errorf("Error sending create event for volume ID=[%s] err=[%v]", vol.UUID, err)
 				delete(currVols, vol.UUID)


### PR DESCRIPTION
- Remove redundant startup parameters and struct properties and just rely on storagepool-driver
- Some script reformatting just because
- Make sure driverName is passed as part of sp event. dont pass spExternalId as part of volume event (had to update godeps go-rancher to get drivername)
- Make sure stack name is used for everything it should be on launchings. Specifically added it for:
  - convoy socket
  - driver name that volume agent was using as the storage pool driver
  - the plugin spec file name
