### PR TITLE
Add support for RancherOS

### DIFF
--- a/packaging/convoy-agent/Dockerfile
+++ b/packaging/convoy-agent/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:15.10
 
 MAINTAINER Rancher Labs, Inc.
 
-RUN apt-get update && apt-get install -y software-properties-common
+RUN apt-get update && apt-get install -y software-properties-common kmod
 RUN add-apt-repository ppa:gluster/glusterfs-3.7 && apt-get update && apt-get install -y curl glusterfs-client
 RUN mkdir -p /var/lib/rancher/convoy-agent && \
     curl -sSL -o convoy.tar.gz https://github.com/rancher/convoy/releases/download/v0.4.1/convoy.tar.gz && tar -xvzf convoy.tar.gz && mv convoy/convoy /var/lib/rancher/convoy-agent && \

--- a/packaging/convoy-agent/launch
+++ b/packaging/convoy-agent/launch
@@ -36,6 +36,12 @@ storagepool_agent() {
 }
 
 volume_agent_glusterfs() {
+    if [ ! -e /dev/fuse ]; then
+        echo Failed to find /dev/fuse attempting: modprobe fuse
+        modprobe fuse
+        exit 1
+    fi
+
     wait_for_metadata
 
     STACK_NAME=$(curl -s http://rancher-metadata/latest/self/stack/name)


### PR DESCRIPTION
This really just dynamically loads fuse, which is common issue on all
OSs, but first seen on RancherOS.
