### PR TITLE
Various fixes

### DIFF
--- a/packaging/convoy-agent/Dockerfile
+++ b/packaging/convoy-agent/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y software-properties-common kmod
 RUN add-apt-repository ppa:gluster/glusterfs-3.7 && apt-get update && apt-get install -y curl glusterfs-client
 RUN mkdir -p /var/lib/rancher/convoy-agent && \
     curl -sSL -o convoy.tar.gz https://github.com/rancher/convoy/releases/download/v0.4.1/convoy.tar.gz && tar -xvzf convoy.tar.gz && mv convoy/convoy /var/lib/rancher/convoy-agent && \
-    curl -sSL -o share-mnt https://github.com/rancher/runc/releases/download/share-mnt-v0.0.2/share-mnt && chmod u+x share-mnt && mv share-mnt /var/lib/rancher/convoy-agent
+    curl -sSL -o share-mnt https://github.com/rancher/runc/releases/download/share-mnt-v0.0.3/share-mnt && chmod u+x share-mnt && mv share-mnt /var/lib/rancher/convoy-agent
 
 ENV PATH /var/lib/rancher/convoy-agent:$PATH
 

--- a/packaging/convoy-agent/launch
+++ b/packaging/convoy-agent/launch
@@ -58,8 +58,8 @@ volume_agent_glusterfs_internal() {
     GLUSTER_STACK_NAME=$(get_metadata gluster_stack)
     SERVICE_NAME=$(get_metadata gluster_service)
     VOLUME_POOL=$(get_metadata volume_pool)
-    CONVOY_SOCK_IN_CON=/host/run/conoy-$STACK_NAME-$STACK_UUID.sock
-    CONVOY_SOCK_ON_HOST=/run/conoy-$STACK_NAME-$STACK_UUID.sock
+    CONVOY_SOCK_IN_CON=/host/var/run/conoy-$STACK_NAME.sock
+    CONVOY_SOCK_ON_HOST=/var/run/conoy-$STACK_NAME.sock
     CONVOY_ROOT=/var/lib/rancher/convoy/$STACK_NAME-$STACK_UUID
 
     echo "Registering convoy socket at $CONVOY_SOCK_ON_HOST"

--- a/scripts/build-image
+++ b/scripts/build-image
@@ -45,3 +45,4 @@ REPO=${REPO:=rancher}
 
 echo "Building Docker image ${REPO}/convoy-agent:${TAG}"
 docker build --rm -t ${REPO}/convoy-agent:${TAG} dist/build/convoy-agent
+echo "Finished building Docker image ${REPO}/convoy-agent:${TAG}"


### PR DESCRIPTION
- Upgrade to share-mnt v0.0.3 to switch to using /var/run instead of /run
- Remove uuid from convoy sock name to address rancher/rancher#2917
- In build-image script, log the image that was built at the end
