### PR TITLE
Configure convoy root path using environment variable

### DIFF
--- a/packaging/convoy-agent/launch
+++ b/packaging/convoy-agent/launch
@@ -47,7 +47,7 @@ common_vars() {
     STACK_UUID=${STACK_UUID:-$(curl -s http://rancher-metadata/2015-07-25/self/stack/uuid)}
     CONVOY_SOCK_IN_CON=/host/var/run/convoy-$STACK_NAME.sock
     CONVOY_SOCK_ON_HOST=/var/run/convoy-$STACK_NAME.sock
-    CONVOY_ROOT=/var/lib/rancher/convoy/$STACK_NAME-$STACK_UUID
+    CONVOY_ROOT=${CONVOY_ROOT:=/var/lib/rancher/convoy/$STACK_NAME-$STACK_UUID}
 }
 
 volume_agent_glusterfs() {


### PR DESCRIPTION
Add support for an environment variable named **CONVOY_ROOT** that can be used to override the convoy root path.

This allow the possibilities to indirectly change the **vfs.path** options of the convoy daemon drivers options.
Which can be interesting when trying to store snapshot backup files in a well known directory
