### PR TITLE
Don't use PPID to get parent pid

### DIFF
--- a/packaging/convoy-agent/launch
+++ b/packaging/convoy-agent/launch
@@ -148,7 +148,9 @@ volume_driver_longhorn_internal() {
 volume_agent_nfs() {
     wait_for_metadata
     common_vars
-    /var/lib/rancher/convoy-agent/share-mnt $CONVOY_ROOT -- /launch  volume-agent-nfs-internal $PPID
+    sleep 1
+    PARENT=$(ps --no-header --pid $$ -o ppid)
+    /var/lib/rancher/convoy-agent/share-mnt $CONVOY_ROOT -- /launch  volume-agent-nfs-internal $PARENT
 }
 
 


### PR DESCRIPTION
We cannot rely on $PPID to get the parent pid of the running process
because in Docker 1.11, there is a short-lived process that is the
parent of the cotainer when it launches, but then that process dies and
the container process's parent changes but the value of $PPID does not
change.

We first sleep to ensure we give the short-lived process time to die
before looking up the parent.
