### PR TITLE
Replaced efs_id and aws_region metadata with efs_server

### DIFF
--- a/packaging/convoy-agent/launch
+++ b/packaging/convoy-agent/launch
@@ -201,7 +201,7 @@ volume_agent_efs_internal() {
     TARGET_PID=${1?"Cannot run without target pid"}
 
     common_vars
-    MNT_HOST=$(eval echo "$(curl -s http://169.254.169.254/latest/meta-data/placement/availability-zone).${MNT_HOST:-$(get_metadata efs_id)}.efs.${AWS_REGION:-$(get_metadata aws_region)}.amazonaws.com")
+    MNT_HOST=${MNT_HOST:-$(get_metadata efs_server)}
     MNT_OPTS="nfsvers=4.1"
     MNT_DIR=${MNT_DIR:-$(get_metadata mount_dir)}
     if [ -n "$MNT_OPTS" ]; then


### PR DESCRIPTION
I think it is more convenient if the user is prompted for the DNS name.

The `aws_regions` are deprecated as it is. AWS EFS is available for more regions than the ones in the catalog.
