### PR TITLE
Revert base image back to Ubuntu 15.10

### DIFF
--- a/packaging/convoy-agent/Dockerfile
+++ b/packaging/convoy-agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:15.10
 
 MAINTAINER Rancher Labs, Inc.
 


### PR DESCRIPTION
NFSv3 is broken in Ubuntu 16.04. https://bugs.launchpad.net/ubuntu/+source/rpcbind/+bug/1558196.
